### PR TITLE
Optimizing golangci-lint run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,6 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/alicenet-config
       - uses: golangci/golangci-lint-action@v3
   
   golang-unit-tests:


### PR DESCRIPTION
## Scope

- Go lint step already installs golang

## Why?

- One less step to run
