### PR TITLE
Hides generated files under bindings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,15 +6,17 @@
 *.bash text eol=lf
 
 # Simplify how generated files work with git/github
-*.capnp.go      -diff -merge
-*.capnp.go      linguist-generated=true
-*.pb.go         -diff -merge
-*.pb.go         linguist-generated=true
-*.swagger.json  -diff -merge
-*.swagger.json  linguist-generated=true
-*_mngen.go      -diff -merge
-*_mngen.go      linguist-generated=true
-*_mngen_test.go -diff -merge
-*_mngen_test.go linguist-generated=true
-*.mockgen.go    -diff -merge
-*.mockgen.go    linguist-generated=true
+*.capnp.go         -diff -merge
+*.capnp.go         linguist-generated=true
+*.pb.go            -diff -merge
+*.pb.go            linguist-generated=true
+*.swagger.json     -diff -merge
+*.swagger.json     linguist-generated=true
+*_mngen.go         -diff -merge
+*_mngen.go         linguist-generated=true
+*_mngen_test.go    -diff -merge
+*_mngen_test.go    linguist-generated=true
+*.mockgen.go       -diff -merge
+*.mockgen.go       linguist-generated=true
+bridge/bindings/** -diff -merge
+bridge/bindings/** linguist-generated=true


### PR DESCRIPTION
## Scope

Hides more generated files under `bridge/bindings`

## Why?

No need to clutter up reviews and diffs.

