### PR TITLE
Fix log level on killed tasks

### DIFF
--- a/layer1/executor/tasks/base_task.go
+++ b/layer1/executor/tasks/base_task.go
@@ -188,10 +188,10 @@ func (bt *BaseTask) Close() {
 // Finish default implementation for the ITask interface
 func (bt *BaseTask) Finish(err error) {
 	if err != nil {
-		if !errors.Is(err, context.Canceled) {
-			bt.logger.WithError(err).Error("got an error when executing task")
+		if bt.wasKilled {
+			bt.logger.WithError(err).Debug("cancelling task execution, task was killed")
 		} else {
-			bt.logger.WithError(err).Debug("cancelling task execution")
+			bt.logger.WithError(err).Error("got an error when executing task")
 		}
 	} else {
 		bt.logger.Info("task is done")


### PR DESCRIPTION
## Scope

When a task is being killed (e.g snapshots) its context (created by the scheduler) is canceled which bubbles up an error. This is normal behavior and should be filtered to not show to the user the message as a level Error. The error level should be only used when I task exits with an error without being killed.  
