### PR TITLE
Fix backoff multiplier in the tx retries

### DIFF
--- a/layer1/transaction/backend.go
+++ b/layer1/transaction/backend.go
@@ -401,7 +401,7 @@ func (wb *WatcherBackend) Loop() {
 
 		case <-poolingTime:
 			wb.collectReceipts()
-			poolingTime = time.After(constants.TxPollingTime)
+			poolingTime = time.After(wb.TxPollingTime)
 			err := wb.PersistState()
 			if err != nil {
 				wb.logger.Errorf("Failed to persist state on the database %v", err)

--- a/layer1/transaction/worker_pool.go
+++ b/layer1/transaction/worker_pool.go
@@ -155,7 +155,11 @@ func (w *WorkerPool) getReceipt(ctx context.Context, monitoredTx info, currentHe
 		// (err tx not found). But in case of an edge case, where tx replacing and tx
 		// replaced are both valid (e.g sending tx to different nodes) we will continue
 		// to retry both, until we have a valid tx for this nonce.
-		maxPendingBlocks := monitoredTx.MaxStaleBlocks * constants.TxBackOffDelayStaleTxMultiplier * (monitoredTx.RetryAmount + 1)
+		maxPendingBlocks := monitoredTx.MaxStaleBlocks * (monitoredTx.RetryAmount + 1)
+		// after first retry we increase the delay between retries
+		if monitoredTx.RetryAmount > 0 {
+			maxPendingBlocks *= constants.TxBackOffDelayStaleTxMultiplier
+		}
 		if blockTimeSpan >= maxPendingBlocks {
 			return nil, &ErrTransactionStale{fmt.Sprintf("error tx: %v is stale on the memory pool for more than %v blocks!", txnHex, maxPendingBlocks)}
 		}


### PR DESCRIPTION
## Scope

The multiplier between retries during some edge cases on the transaction watcher should wait for the first retry to be applied. This PR also fixes a small bug where the correct polling time was not being applied to the watcher backend. 