### PR TITLE
Remove singleton pattern from ethereum smart contracts setup

### DIFF
--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -67,7 +67,7 @@ func LogStatus(logger *logrus.Entry, eth layer1.Client, contracts layer1.AllSmar
 		return
 	}
 
-	c := contracts.GetEthereumContracts()
+	c := contracts.EthereumContracts()
 	callOpts, err := eth.GetCallOpts(context.Background(), acct)
 	if err != nil {
 		logger.Warnf("Failed to get call options: %v", err)

--- a/cmd/validator/validator.go
+++ b/cmd/validator/validator.go
@@ -290,7 +290,7 @@ func validatorNode(cmd *cobra.Command, args []string) {
 	}
 
 	monitorInterval := config.Configuration.Monitor.Interval
-	mon, err := monitor.NewMonitor(consDB, monDB, consAdminHandlers, appDepositHandler, eth, contractsHandler, contractsHandler.GetEthereumContracts().GetAllAddresses(), monitorInterval, uint64(batchSize), taskRequestChan)
+	mon, err := monitor.NewMonitor(consDB, monDB, consAdminHandlers, appDepositHandler, eth, contractsHandler, contractsHandler.EthereumContracts().GetAllAddresses(), monitorInterval, uint64(batchSize), taskRequestChan)
 	if err != nil {
 		panic(err)
 	}

--- a/layer1/ethereum/ethereum.go
+++ b/layer1/ethereum/ethereum.go
@@ -699,13 +699,12 @@ func (eth *Client) CreateSecp256k1Signer() (*crypto.Secp256k1Signer, error) {
 ////////////////////////////////////////////////////////////////
 
 // Get the current validators
-func GetValidators(eth layer1.Client, logger *logrus.Logger, ctx context.Context) ([]common.Address, error) {
-	c := GetContracts()
+func GetValidators(eth layer1.Client, contracts layer1.EthereumContracts, logger *logrus.Logger, ctx context.Context) ([]common.Address, error) {
 	callOpts, err := eth.GetCallOpts(ctx, eth.GetDefaultAccount())
 	if err != nil {
 		return nil, err
 	}
-	validatorAddresses, err := c.ValidatorPool().GetValidatorsAddresses(callOpts)
+	validatorAddresses, err := contracts.ValidatorPool().GetValidatorsAddresses(callOpts)
 	if err != nil {
 		logger.Warnf("Could not call contract:%v", err)
 		return nil, err

--- a/layer1/ethereum/tests/setup_test.go
+++ b/layer1/ethereum/tests/setup_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/alicenet/alicenet/layer1"
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/tests"
 	"github.com/alicenet/alicenet/logging"
 	"github.com/sirupsen/logrus"
@@ -29,7 +28,6 @@ func setupEthereum(t *testing.T, n int, unlockAllAccounts bool) (*tests.ClientFi
 
 	t.Cleanup(func() {
 		fixture.Close()
-		ethereum.CleanGlobalVariables(t)
 	})
 
 	return fixture, eth, logger

--- a/layer1/executor/task_manager.go
+++ b/layer1/executor/task_manager.go
@@ -71,9 +71,9 @@ func (tm *TasksManager) GetTxBackup(uuid string) (*types.Transaction, bool) {
 
 // main function to manage a task. It basically an abstraction to handle the
 // task execution in a separate process.
-func (tm *TasksManager) ManageTask(mainCtx context.Context, task tasks.Task, name string, taskId string, database *db.Database, logger *logrus.Entry, eth layer1.Client, taskResponseChan tasks.TaskResponseChan) {
+func (tm *TasksManager) ManageTask(mainCtx context.Context, task tasks.Task, name string, taskId string, database *db.Database, logger *logrus.Entry, eth layer1.Client, contracts layer1.AllSmartContracts, taskResponseChan tasks.TaskResponseChan) {
 	defer task.Close()
-	err := tm.processTask(mainCtx, task, name, taskId, database, logger, eth, taskResponseChan)
+	err := tm.processTask(mainCtx, task, name, taskId, database, logger, eth, contracts, taskResponseChan)
 	// Clean up in case the task was killed
 	if task.WasKilled() {
 		task.GetLogger().Trace("task was externally killed, removing tx backup")
@@ -82,10 +82,10 @@ func (tm *TasksManager) ManageTask(mainCtx context.Context, task tasks.Task, nam
 	task.Finish(err)
 }
 
-func (tm *TasksManager) processTask(mainCtx context.Context, task tasks.Task, name string, taskId string, database *db.Database, logger *logrus.Entry, eth layer1.Client, taskResponseChan tasks.TaskResponseChan) error {
+func (tm *TasksManager) processTask(mainCtx context.Context, task tasks.Task, name string, taskId string, database *db.Database, logger *logrus.Entry, eth layer1.Client, contracts layer1.AllSmartContracts, taskResponseChan tasks.TaskResponseChan) error {
 	taskCtx, cf := context.WithCancel(mainCtx)
 	defer cf()
-	err := task.Initialize(taskCtx, cf, database, logger, eth, name, taskId, taskResponseChan)
+	err := task.Initialize(taskCtx, cf, database, logger, eth, contracts, name, taskId, taskResponseChan)
 	if err != nil {
 		return err
 	}

--- a/layer1/executor/tasks/base_task.go
+++ b/layer1/executor/tasks/base_task.go
@@ -67,6 +67,9 @@ type BaseTask struct {
 	taskResponseChan    TaskResponseChan              `json:"-"`
 }
 
+// NewBaseTask creates a new Base task. BaseTask should be the base of any task.
+// This function is called outside the scheduler o create the object to be
+// scheduled.
 func NewBaseTask(start uint64, end uint64, allowMultiExecution bool, subscribeOptions *transaction.SubscribeOptions) *BaseTask {
 	ctx, cf := context.WithCancel(context.Background())
 
@@ -80,7 +83,9 @@ func NewBaseTask(start uint64, end uint64, allowMultiExecution bool, subscribeOp
 	}
 }
 
-// Initialize default implementation for the ITask interface
+// Initialize initializes the task after its creation. It should be only called
+// by the task scheduler during task spawn as separated go routine. This
+// function all the parameters for task execution and control by the scheduler.
 func (bt *BaseTask) Initialize(ctx context.Context, cancelFunc context.CancelFunc, database *db.Database, logger *logrus.Entry, eth layer1.Client, contracts layer1.AllSmartContracts, name string, id string, taskResponseChan TaskResponseChan) error {
 	bt.Lock()
 	defer bt.Unlock()
@@ -102,89 +107,96 @@ func (bt *BaseTask) Initialize(ctx context.Context, cancelFunc context.CancelFun
 	return nil
 }
 
-// GetId default implementation for the ITask interface
+// GetId gets the task unique ID.
 func (bt *BaseTask) GetId() string {
 	bt.RLock()
 	defer bt.RUnlock()
 	return bt.Id
 }
 
-// GetStart default implementation for the ITask interface
+// GetStart gets the start date of a task. Returns 0 if a task does not has a
+// start date (started immediately).
 func (bt *BaseTask) GetStart() uint64 {
 	bt.RLock()
 	defer bt.RUnlock()
 	return bt.Start
 }
 
-// GetEnd default implementation for the ITask interface
+// GetEnd gets the end date in blocks of a task. In case 0, the task does not
+// has a end block.
 func (bt *BaseTask) GetEnd() uint64 {
 	bt.RLock()
 	defer bt.RUnlock()
 	return bt.End
 }
 
-// GetName default implementation for the ITask interface
+// GetName get the name of the task.
 func (bt *BaseTask) GetName() string {
 	bt.RLock()
 	defer bt.RUnlock()
 	return bt.Name
 }
 
-// GetAllowMultiExecution default implementation for the ITask interface
+// GetAllowMultiExecution returns if a task type allows multiple execution.
 func (bt *BaseTask) GetAllowMultiExecution() bool {
 	bt.RLock()
 	defer bt.RUnlock()
 	return bt.AllowMultiExecution
 }
 
+// GetSubscribeOptions gets the transactionWatcher subscribeOptions specific for
+// a task.
 func (bt *BaseTask) GetSubscribeOptions() *transaction.SubscribeOptions {
 	bt.RLock()
 	defer bt.RUnlock()
 	return bt.SubscribeOptions
 }
 
-// GetCtx default implementation for the ITask interface
+// GetCtx get the context to be used by a task.
 func (bt *BaseTask) GetCtx() context.Context {
 	bt.RLock()
 	defer bt.RUnlock()
 	return bt.ctx
 }
 
-// GetCtx default implementation for the ITask interface
+// WasKilled returns true if the task was killed otherwise false.
 func (bt *BaseTask) WasKilled() bool {
 	bt.RLock()
 	defer bt.RUnlock()
 	return bt.wasKilled
 }
 
-// GetEth default implementation for the ITask interface
+// GetClient returns the layer1 client implemented by the task.
 func (bt *BaseTask) GetClient() layer1.Client {
 	bt.RLock()
 	defer bt.RUnlock()
 	return bt.client
 }
 
-// GetEth default implementation for the ITask interface
+// GetContractsHandler returns the handler that has access to all different
+// layer1 smart contracts.
 func (bt *BaseTask) GetContractsHandler() layer1.AllSmartContracts {
 	bt.RLock()
 	defer bt.RUnlock()
 	return bt.contracts
 }
 
-// GetLogger default implementation for the ITask interface
+// GetLogger returns the task logger.
 func (bt *BaseTask) GetLogger() *logrus.Entry {
 	bt.RLock()
 	defer bt.RUnlock()
 	return bt.logger
 }
 
+// GetDB returns the database where the task can save and load its state.
 func (bt *BaseTask) GetDB() *db.Database {
 	bt.RLock()
 	defer bt.RUnlock()
 	return bt.database
 }
 
-// Close default implementation for the ITask interface
+// Close closes a running task. It set a bool flag and call the cancelFunc in
+// case its different from nil.
 func (bt *BaseTask) Close() {
 	bt.Lock()
 	defer bt.Unlock()
@@ -194,7 +206,7 @@ func (bt *BaseTask) Close() {
 	bt.wasKilled = true
 }
 
-// Finish default implementation for the ITask interface
+// Finish executes the clean up logic once a task finishes.
 func (bt *BaseTask) Finish(err error) {
 	if err != nil {
 		if bt.wasKilled {

--- a/layer1/executor/tasks/base_task.go
+++ b/layer1/executor/tasks/base_task.go
@@ -63,6 +63,7 @@ type BaseTask struct {
 	database            *db.Database                  `json:"-"`
 	logger              *logrus.Entry                 `json:"-"`
 	client              layer1.Client                 `json:"-"`
+	contracts           layer1.AllSmartContracts      `json:"-"`
 	taskResponseChan    TaskResponseChan              `json:"-"`
 }
 
@@ -80,7 +81,7 @@ func NewBaseTask(start uint64, end uint64, allowMultiExecution bool, subscribeOp
 }
 
 // Initialize default implementation for the ITask interface
-func (bt *BaseTask) Initialize(ctx context.Context, cancelFunc context.CancelFunc, database *db.Database, logger *logrus.Entry, eth layer1.Client, name string, id string, taskResponseChan TaskResponseChan) error {
+func (bt *BaseTask) Initialize(ctx context.Context, cancelFunc context.CancelFunc, database *db.Database, logger *logrus.Entry, eth layer1.Client, contracts layer1.AllSmartContracts, name string, id string, taskResponseChan TaskResponseChan) error {
 	bt.Lock()
 	defer bt.Unlock()
 	if bt.isInitialized {
@@ -94,6 +95,7 @@ func (bt *BaseTask) Initialize(ctx context.Context, cancelFunc context.CancelFun
 	bt.database = database
 	bt.logger = logger
 	bt.client = eth
+	bt.contracts = contracts
 	bt.taskResponseChan = taskResponseChan
 	bt.isInitialized = true
 
@@ -160,6 +162,13 @@ func (bt *BaseTask) GetClient() layer1.Client {
 	bt.RLock()
 	defer bt.RUnlock()
 	return bt.client
+}
+
+// GetEth default implementation for the ITask interface
+func (bt *BaseTask) GetContractsHandler() layer1.AllSmartContracts {
+	bt.RLock()
+	defer bt.RUnlock()
+	return bt.contracts
 }
 
 // GetLogger default implementation for the ITask interface

--- a/layer1/executor/tasks/dkg/completion.go
+++ b/layer1/executor/tasks/dkg/completion.go
@@ -71,7 +71,7 @@ func (t *CompletionTask) Execute(ctx context.Context) (*types.Transaction, *task
 		return nil, tasks.NewTaskErr("not leading Completion yet", true)
 	}
 
-	c := t.GetContractsHandler().GetEthereumContracts()
+	c := t.GetContractsHandler().EthereumContracts()
 	txnOpts, err := client.GetTransactionOpts(ctx, dkgState.Account)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingTxnOpts, err), true)
@@ -93,7 +93,7 @@ func (t *CompletionTask) ShouldExecute(ctx context.Context) (bool, *tasks.TaskEr
 	logger.Debug("should execute task")
 
 	eth := t.GetClient()
-	c := t.GetContractsHandler().GetEthereumContracts()
+	c := t.GetContractsHandler().EthereumContracts()
 
 	callOpts, err := eth.GetCallOpts(ctx, eth.GetDefaultAccount())
 	if err != nil {

--- a/layer1/executor/tasks/dkg/completion.go
+++ b/layer1/executor/tasks/dkg/completion.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/utils"
@@ -72,7 +71,7 @@ func (t *CompletionTask) Execute(ctx context.Context) (*types.Transaction, *task
 		return nil, tasks.NewTaskErr("not leading Completion yet", true)
 	}
 
-	c := ethereum.GetContracts()
+	c := t.GetContractsHandler().GetEthereumContracts()
 	txnOpts, err := client.GetTransactionOpts(ctx, dkgState.Account)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingTxnOpts, err), true)
@@ -94,7 +93,7 @@ func (t *CompletionTask) ShouldExecute(ctx context.Context) (bool, *tasks.TaskEr
 	logger.Debug("should execute task")
 
 	eth := t.GetClient()
-	c := ethereum.GetContracts()
+	c := t.GetContractsHandler().GetEthereumContracts()
 
 	callOpts, err := eth.GetCallOpts(ctx, eth.GetDefaultAccount())
 	if err != nil {

--- a/layer1/executor/tasks/dkg/dispute_gpkj.go
+++ b/layer1/executor/tasks/dkg/dispute_gpkj.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/alicenet/alicenet/crypto"
 	"github.com/alicenet/alicenet/crypto/bn256"
-	"github.com/alicenet/alicenet/layer1/ethereum"
 
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
@@ -161,7 +160,7 @@ func (t *DisputeGPKjTask) accuseDishonestValidator(ctx context.Context, logger *
 	}
 
 	logger.Warnf("accusing participant: %v of distributing bad dpkj", t.Address.Hex())
-	txn, err := ethereum.GetContracts().Ethdkg().AccuseParticipantSubmittedBadGPKJ(txnOpts, validatorAddresses, groupEncryptedSharesHash, groupCommitments, t.Address)
+	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().AccuseParticipantSubmittedBadGPKJ(txnOpts, validatorAddresses, groupEncryptedSharesHash, groupCommitments, t.Address)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("bad dpkj accusation failed: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/dispute_gpkj.go
+++ b/layer1/executor/tasks/dkg/dispute_gpkj.go
@@ -160,7 +160,7 @@ func (t *DisputeGPKjTask) accuseDishonestValidator(ctx context.Context, logger *
 	}
 
 	logger.Warnf("accusing participant: %v of distributing bad dpkj", t.Address.Hex())
-	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().AccuseParticipantSubmittedBadGPKJ(txnOpts, validatorAddresses, groupEncryptedSharesHash, groupCommitments, t.Address)
+	txn, err := t.GetContractsHandler().EthereumContracts().Ethdkg().AccuseParticipantSubmittedBadGPKJ(txnOpts, validatorAddresses, groupEncryptedSharesHash, groupCommitments, t.Address)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("bad dpkj accusation failed: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/dispute_missing_gpkj.go
+++ b/layer1/executor/tasks/dkg/dispute_missing_gpkj.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/utils"
@@ -63,7 +62,7 @@ func (t *DisputeMissingGPKjTask) Execute(ctx context.Context) (*types.Transactio
 	}
 
 	logger.Warnf("accusing missing gpkj: %v", accusableParticipants)
-	txn, err := ethereum.GetContracts().Ethdkg().AccuseParticipantDidNotSubmitGPKJ(txnOpts, accusableParticipants)
+	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().AccuseParticipantDidNotSubmitGPKJ(txnOpts, accusableParticipants)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("error accusing missing gpkj: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/dispute_missing_gpkj.go
+++ b/layer1/executor/tasks/dkg/dispute_missing_gpkj.go
@@ -62,7 +62,7 @@ func (t *DisputeMissingGPKjTask) Execute(ctx context.Context) (*types.Transactio
 	}
 
 	logger.Warnf("accusing missing gpkj: %v", accusableParticipants)
-	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().AccuseParticipantDidNotSubmitGPKJ(txnOpts, accusableParticipants)
+	txn, err := t.GetContractsHandler().EthereumContracts().Ethdkg().AccuseParticipantDidNotSubmitGPKJ(txnOpts, accusableParticipants)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("error accusing missing gpkj: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/dispute_missing_key_shares.go
+++ b/layer1/executor/tasks/dkg/dispute_missing_key_shares.go
@@ -63,7 +63,7 @@ func (t *DisputeMissingKeySharesTask) Execute(ctx context.Context) (*types.Trans
 		return nil, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingTxnOpts, err), true)
 	}
 
-	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().AccuseParticipantDidNotSubmitKeyShares(txnOpts, accusableParticipants)
+	txn, err := t.GetContractsHandler().EthereumContracts().Ethdkg().AccuseParticipantDidNotSubmitKeyShares(txnOpts, accusableParticipants)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("error accusing missing key shares: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/dispute_missing_key_shares.go
+++ b/layer1/executor/tasks/dkg/dispute_missing_key_shares.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/utils"
@@ -64,7 +63,7 @@ func (t *DisputeMissingKeySharesTask) Execute(ctx context.Context) (*types.Trans
 		return nil, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingTxnOpts, err), true)
 	}
 
-	txn, err := ethereum.GetContracts().Ethdkg().AccuseParticipantDidNotSubmitKeyShares(txnOpts, accusableParticipants)
+	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().AccuseParticipantDidNotSubmitKeyShares(txnOpts, accusableParticipants)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("error accusing missing key shares: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/dispute_missing_registration.go
+++ b/layer1/executor/tasks/dkg/dispute_missing_registration.go
@@ -64,7 +64,7 @@ func (t *DisputeMissingRegistrationTask) Execute(ctx context.Context) (*types.Tr
 		return nil, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingTxnOpts, err), true)
 	}
 
-	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().AccuseParticipantNotRegistered(txnOpts, accusableParticipants)
+	txn, err := t.GetContractsHandler().EthereumContracts().Ethdkg().AccuseParticipantNotRegistered(txnOpts, accusableParticipants)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("error accusing missing registration: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/dispute_missing_registration.go
+++ b/layer1/executor/tasks/dkg/dispute_missing_registration.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/utils"
@@ -65,7 +64,7 @@ func (t *DisputeMissingRegistrationTask) Execute(ctx context.Context) (*types.Tr
 		return nil, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingTxnOpts, err), true)
 	}
 
-	txn, err := ethereum.GetContracts().Ethdkg().AccuseParticipantNotRegistered(txnOpts, accusableParticipants)
+	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().AccuseParticipantNotRegistered(txnOpts, accusableParticipants)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("error accusing missing registration: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/dispute_missing_share_distribution.go
+++ b/layer1/executor/tasks/dkg/dispute_missing_share_distribution.go
@@ -61,7 +61,7 @@ func (t *DisputeMissingShareDistributionTask) Execute(ctx context.Context) (*typ
 	}
 
 	logger.Warnf("accusing participants: %v of not distributing shares", accusableParticipants)
-	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().AccuseParticipantDidNotDistributeShares(txnOpts, accusableParticipants)
+	txn, err := t.GetContractsHandler().EthereumContracts().Ethdkg().AccuseParticipantDidNotDistributeShares(txnOpts, accusableParticipants)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("error accusing missing key shares: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/dispute_missing_share_distribution.go
+++ b/layer1/executor/tasks/dkg/dispute_missing_share_distribution.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/utils"
@@ -62,7 +61,7 @@ func (t *DisputeMissingShareDistributionTask) Execute(ctx context.Context) (*typ
 	}
 
 	logger.Warnf("accusing participants: %v of not distributing shares", accusableParticipants)
-	txn, err := ethereum.GetContracts().Ethdkg().AccuseParticipantDidNotDistributeShares(txnOpts, accusableParticipants)
+	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().AccuseParticipantDidNotDistributeShares(txnOpts, accusableParticipants)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("error accusing missing key shares: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/dispute_share_distribution.go
+++ b/layer1/executor/tasks/dkg/dispute_share_distribution.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/alicenet/alicenet/crypto/bn256"
 	"github.com/alicenet/alicenet/crypto/bn256/cloudflare"
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/utils"
@@ -130,7 +129,7 @@ func (t *DisputeShareDistributionTask) Execute(ctx context.Context) (*types.Tran
 		return nil, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingTxnOpts, err), true)
 	}
 	// Accuse participant
-	txn, err := ethereum.GetContracts().Ethdkg().AccuseParticipantDistributedBadShares(txnOpts, dishonestAddress, encryptedShares, commitments, sharedKey, sharedKeyProof)
+	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().AccuseParticipantDistributedBadShares(txnOpts, dishonestAddress, encryptedShares, commitments, sharedKey, sharedKeyProof)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("submit share dispute failed: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/dispute_share_distribution.go
+++ b/layer1/executor/tasks/dkg/dispute_share_distribution.go
@@ -129,7 +129,7 @@ func (t *DisputeShareDistributionTask) Execute(ctx context.Context) (*types.Tran
 		return nil, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingTxnOpts, err), true)
 	}
 	// Accuse participant
-	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().AccuseParticipantDistributedBadShares(txnOpts, dishonestAddress, encryptedShares, commitments, sharedKey, sharedKeyProof)
+	txn, err := t.GetContractsHandler().EthereumContracts().Ethdkg().AccuseParticipantDistributedBadShares(txnOpts, dishonestAddress, encryptedShares, commitments, sharedKey, sharedKeyProof)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("submit share dispute failed: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/gpkj_submission.go
+++ b/layer1/executor/tasks/dkg/gpkj_submission.go
@@ -104,7 +104,7 @@ func (t *GPKjSubmissionTask) Execute(ctx context.Context) (*types.Transaction, *
 	}
 
 	logger.Infof("submitting gpkj: %v", dkgState.Participants[dkgState.Account.Address].GPKj)
-	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().SubmitGPKJ(txnOpts, dkgState.Participants[dkgState.Account.Address].GPKj)
+	txn, err := t.GetContractsHandler().EthereumContracts().Ethdkg().SubmitGPKJ(txnOpts, dkgState.Participants[dkgState.Account.Address].GPKj)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("submitting gpkj failed: %v", err), true)
 	}
@@ -134,7 +134,7 @@ func (t *GPKjSubmissionTask) ShouldExecute(ctx context.Context) (bool, *tasks.Ta
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingCallOpts, err), true)
 	}
-	participantState, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, defaultAddr.Address)
+	participantState, err := t.GetContractsHandler().EthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, defaultAddr.Address)
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("failed getting participants state: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/gpkj_submission.go
+++ b/layer1/executor/tasks/dkg/gpkj_submission.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/alicenet/alicenet/constants"
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	monInterfaces "github.com/alicenet/alicenet/layer1/monitor/interfaces"
@@ -105,7 +104,7 @@ func (t *GPKjSubmissionTask) Execute(ctx context.Context) (*types.Transaction, *
 	}
 
 	logger.Infof("submitting gpkj: %v", dkgState.Participants[dkgState.Account.Address].GPKj)
-	txn, err := ethereum.GetContracts().Ethdkg().SubmitGPKJ(txnOpts, dkgState.Participants[dkgState.Account.Address].GPKj)
+	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().SubmitGPKJ(txnOpts, dkgState.Participants[dkgState.Account.Address].GPKj)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("submitting gpkj failed: %v", err), true)
 	}
@@ -135,7 +134,7 @@ func (t *GPKjSubmissionTask) ShouldExecute(ctx context.Context) (bool, *tasks.Ta
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingCallOpts, err), true)
 	}
-	participantState, err := ethereum.GetContracts().Ethdkg().GetParticipantInternalState(callOpts, defaultAddr.Address)
+	participantState, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, defaultAddr.Address)
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("failed getting participants state: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/keyshare_submission.go
+++ b/layer1/executor/tasks/dkg/keyshare_submission.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
-
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 )
@@ -98,7 +96,7 @@ func (t *KeyShareSubmissionTask) Execute(ctx context.Context) (*types.Transactio
 		dkgState.Participants[defaultAddr.Address].KeyShareG1CorrectnessProofs,
 		dkgState.Participants[defaultAddr.Address].KeyShareG2s,
 	)
-	txn, err := ethereum.GetContracts().Ethdkg().SubmitKeyShare(txnOpts,
+	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().SubmitKeyShare(txnOpts,
 		dkgState.Participants[defaultAddr.Address].KeyShareG1s,
 		dkgState.Participants[defaultAddr.Address].KeyShareG1CorrectnessProofs,
 		dkgState.Participants[defaultAddr.Address].KeyShareG2s)
@@ -126,7 +124,7 @@ func (t *KeyShareSubmissionTask) ShouldExecute(ctx context.Context) (bool, *task
 		return false, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingCallOpts, err), true)
 	}
 
-	phase, err := ethereum.GetContracts().Ethdkg().GetETHDKGPhase(callOpts)
+	phase, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().GetETHDKGPhase(callOpts)
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("error getting ETHDKGPhase: %v", err), true)
 	}
@@ -138,7 +136,7 @@ func (t *KeyShareSubmissionTask) ShouldExecute(ctx context.Context) (bool, *task
 	}
 
 	// Check the key share submission status
-	status, err := state.CheckKeyShare(ctx, ethereum.GetContracts().Ethdkg(), logger, callOpts, defaultAccount.Address, dkgState.Participants[defaultAccount.Address].KeyShareG1s)
+	status, err := state.CheckKeyShare(ctx, t.GetContractsHandler().GetEthereumContracts().Ethdkg(), logger, callOpts, defaultAccount.Address, dkgState.Participants[defaultAccount.Address].KeyShareG1s)
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("error checkingKeyShare: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/keyshare_submission.go
+++ b/layer1/executor/tasks/dkg/keyshare_submission.go
@@ -96,7 +96,7 @@ func (t *KeyShareSubmissionTask) Execute(ctx context.Context) (*types.Transactio
 		dkgState.Participants[defaultAddr.Address].KeyShareG1CorrectnessProofs,
 		dkgState.Participants[defaultAddr.Address].KeyShareG2s,
 	)
-	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().SubmitKeyShare(txnOpts,
+	txn, err := t.GetContractsHandler().EthereumContracts().Ethdkg().SubmitKeyShare(txnOpts,
 		dkgState.Participants[defaultAddr.Address].KeyShareG1s,
 		dkgState.Participants[defaultAddr.Address].KeyShareG1CorrectnessProofs,
 		dkgState.Participants[defaultAddr.Address].KeyShareG2s)
@@ -124,7 +124,7 @@ func (t *KeyShareSubmissionTask) ShouldExecute(ctx context.Context) (bool, *task
 		return false, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingCallOpts, err), true)
 	}
 
-	phase, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().GetETHDKGPhase(callOpts)
+	phase, err := t.GetContractsHandler().EthereumContracts().Ethdkg().GetETHDKGPhase(callOpts)
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("error getting ETHDKGPhase: %v", err), true)
 	}
@@ -136,7 +136,7 @@ func (t *KeyShareSubmissionTask) ShouldExecute(ctx context.Context) (bool, *task
 	}
 
 	// Check the key share submission status
-	status, err := state.CheckKeyShare(ctx, t.GetContractsHandler().GetEthereumContracts().Ethdkg(), logger, callOpts, defaultAccount.Address, dkgState.Participants[defaultAccount.Address].KeyShareG1s)
+	status, err := state.CheckKeyShare(ctx, t.GetContractsHandler().EthereumContracts().Ethdkg(), logger, callOpts, defaultAccount.Address, dkgState.Participants[defaultAccount.Address].KeyShareG1s)
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("error checkingKeyShare: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/mpk_submission.go
+++ b/layer1/executor/tasks/dkg/mpk_submission.go
@@ -137,7 +137,7 @@ func (t *MPKSubmissionTask) Execute(ctx context.Context) (*types.Transaction, *t
 
 	// Submit MPK
 	logger.Infof("submitting master public key:%v", dkgState.MasterPublicKey)
-	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().SubmitMasterPublicKey(txnOpts, dkgState.MasterPublicKey)
+	txn, err := t.GetContractsHandler().EthereumContracts().Ethdkg().SubmitMasterPublicKey(txnOpts, dkgState.MasterPublicKey)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("submitting master public key failed: %v", err), true)
 	}
@@ -173,7 +173,7 @@ func (t *MPKSubmissionTask) ShouldExecute(ctx context.Context) (bool, *tasks.Tas
 		return false, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingCallOpts, err), true)
 	}
 
-	mpkHash, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().GetMasterPublicKeyHash(callOpts)
+	mpkHash, err := t.GetContractsHandler().EthereumContracts().Ethdkg().GetMasterPublicKeyHash(callOpts)
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("failed to retrieve mpk from smart contracts: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/mpk_submission.go
+++ b/layer1/executor/tasks/dkg/mpk_submission.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/alicenet/alicenet/crypto"
 	"github.com/alicenet/alicenet/crypto/bn256"
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/utils"
@@ -138,7 +137,7 @@ func (t *MPKSubmissionTask) Execute(ctx context.Context) (*types.Transaction, *t
 
 	// Submit MPK
 	logger.Infof("submitting master public key:%v", dkgState.MasterPublicKey)
-	txn, err := ethereum.GetContracts().Ethdkg().SubmitMasterPublicKey(txnOpts, dkgState.MasterPublicKey)
+	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().SubmitMasterPublicKey(txnOpts, dkgState.MasterPublicKey)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("submitting master public key failed: %v", err), true)
 	}
@@ -174,7 +173,7 @@ func (t *MPKSubmissionTask) ShouldExecute(ctx context.Context) (bool, *tasks.Tas
 		return false, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingCallOpts, err), true)
 	}
 
-	mpkHash, err := ethereum.GetContracts().Ethdkg().GetMasterPublicKeyHash(callOpts)
+	mpkHash, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().GetMasterPublicKeyHash(callOpts)
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("failed to retrieve mpk from smart contracts: %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/register.go
+++ b/layer1/executor/tasks/dkg/register.go
@@ -91,7 +91,7 @@ func (t *RegisterTask) Execute(ctx context.Context) (*types.Transaction, *tasks.
 	// Register
 	logger.Infof("Registering  publicKey (%v) with ETHDKG", utils.FormatPublicKey(dkgState.TransportPublicKey))
 	logger.Debugf("registering on block %v with public key: %v", block, utils.FormatPublicKey(dkgState.TransportPublicKey))
-	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().Register(txnOpts, dkgState.TransportPublicKey)
+	txn, err := t.GetContractsHandler().EthereumContracts().Ethdkg().Register(txnOpts, dkgState.TransportPublicKey)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("registering failed: %v", err), true)
 	}
@@ -120,7 +120,7 @@ func (t *RegisterTask) ShouldExecute(ctx context.Context) (bool, *tasks.TaskErr)
 		return false, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingCallOpts, err), true)
 	}
 
-	status, err := state.CheckRegistration(t.GetContractsHandler().GetEthereumContracts().Ethdkg(), logger, callOpts, dkgState.Account.Address, dkgState.TransportPublicKey)
+	status, err := state.CheckRegistration(t.GetContractsHandler().EthereumContracts().Ethdkg(), logger, callOpts, dkgState.Account.Address, dkgState.TransportPublicKey)
 	logger.Debugf("registration status: %v", status)
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("failed to check registration %v", err), true)

--- a/layer1/executor/tasks/dkg/register.go
+++ b/layer1/executor/tasks/dkg/register.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
-
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/utils"
@@ -93,7 +91,7 @@ func (t *RegisterTask) Execute(ctx context.Context) (*types.Transaction, *tasks.
 	// Register
 	logger.Infof("Registering  publicKey (%v) with ETHDKG", utils.FormatPublicKey(dkgState.TransportPublicKey))
 	logger.Debugf("registering on block %v with public key: %v", block, utils.FormatPublicKey(dkgState.TransportPublicKey))
-	txn, err := ethereum.GetContracts().Ethdkg().Register(txnOpts, dkgState.TransportPublicKey)
+	txn, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().Register(txnOpts, dkgState.TransportPublicKey)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("registering failed: %v", err), true)
 	}
@@ -122,7 +120,7 @@ func (t *RegisterTask) ShouldExecute(ctx context.Context) (bool, *tasks.TaskErr)
 		return false, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingCallOpts, err), true)
 	}
 
-	status, err := state.CheckRegistration(ethereum.GetContracts().Ethdkg(), logger, callOpts, dkgState.Account.Address, dkgState.TransportPublicKey)
+	status, err := state.CheckRegistration(t.GetContractsHandler().GetEthereumContracts().Ethdkg(), logger, callOpts, dkgState.Account.Address, dkgState.TransportPublicKey)
 	logger.Debugf("registration status: %v", status)
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("failed to check registration %v", err), true)

--- a/layer1/executor/tasks/dkg/share_distribution.go
+++ b/layer1/executor/tasks/dkg/share_distribution.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
-
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -85,7 +83,7 @@ func (t *ShareDistributionTask) Execute(ctx context.Context) (*types.Transaction
 	}
 
 	client := t.GetClient()
-	contracts := ethereum.GetContracts()
+	contracts := t.GetContractsHandler().GetEthereumContracts()
 	accountAddr := dkgState.Account.Address
 
 	// Setup
@@ -129,7 +127,7 @@ func (t *ShareDistributionTask) ShouldExecute(ctx context.Context) (bool, *tasks
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("failed getting call options: %v", err), true)
 	}
-	participantState, err := ethereum.GetContracts().Ethdkg().GetParticipantInternalState(callOpts, dkgState.Account.Address)
+	participantState, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, dkgState.Account.Address)
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("unable to GetParticipantInternalState(): %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/share_distribution.go
+++ b/layer1/executor/tasks/dkg/share_distribution.go
@@ -83,7 +83,7 @@ func (t *ShareDistributionTask) Execute(ctx context.Context) (*types.Transaction
 	}
 
 	client := t.GetClient()
-	contracts := t.GetContractsHandler().GetEthereumContracts()
+	contracts := t.GetContractsHandler().EthereumContracts()
 	accountAddr := dkgState.Account.Address
 
 	// Setup
@@ -127,7 +127,7 @@ func (t *ShareDistributionTask) ShouldExecute(ctx context.Context) (bool, *tasks
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("failed getting call options: %v", err), true)
 	}
-	participantState, err := t.GetContractsHandler().GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, dkgState.Account.Address)
+	participantState, err := t.GetContractsHandler().EthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, dkgState.Account.Address)
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("unable to GetParticipantInternalState(): %v", err), true)
 	}

--- a/layer1/executor/tasks/dkg/tests/completion_test.go
+++ b/layer1/executor/tasks/dkg/tests/completion_test.go
@@ -42,7 +42,7 @@ func TestCompletion_Group_1_AllGood(t *testing.T) {
 		for j := 0; j < n; j++ {
 			disputeGPKjTask := suite.DisputeGPKjTasks[idx][j]
 
-			err := disputeGPKjTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "disputeGPKjTask", "task-id", nil)
+			err := disputeGPKjTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "disputeGPKjTask", "task-id", nil)
 			assert.Nil(t, err)
 			err = disputeGPKjTask.Prepare(ctx)
 			assert.Nil(t, err)
@@ -64,7 +64,7 @@ func TestCompletion_Group_1_AllGood(t *testing.T) {
 	for idx := 0; idx < n; idx++ {
 		completionTask := suite.CompletionTasks[idx]
 
-		err := completionTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "CompletionTask", "task-id", nil)
+		err := completionTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "CompletionTask", "task-id", nil)
 		assert.Nil(t, err)
 		err = completionTask.Prepare(ctx)
 		assert.Nil(t, err)
@@ -104,7 +104,7 @@ func TestCompletion_Group_1_Bad1(t *testing.T) {
 	tests.AdvanceTo(suite.Eth, dkgState.PhaseStart+dkgState.PhaseLength)
 
 	task := suite.CompletionTasks[0]
-	err = task.Initialize(ctx, nil, suite.DKGStatesDbs[0], fixture.Logger, suite.Eth, "CompletionTask", "task-id", nil)
+	err = task.Initialize(ctx, nil, suite.DKGStatesDbs[0], fixture.Logger, suite.Eth, fixture.Contracts, "CompletionTask", "task-id", nil)
 	assert.Nil(t, err)
 
 	err = task.Prepare(ctx)
@@ -124,7 +124,7 @@ func TestCompletion_Group_1_Bad2(t *testing.T) {
 	db := mocks.NewTestDB()
 	log := logging.GetLogger("test").WithField("test", "test")
 
-	err := task.Initialize(context.Background(), nil, db, log, nil, "", "", nil)
+	err := task.Initialize(context.Background(), nil, db, log, nil, nil, "", "", nil)
 	assert.Nil(t, err)
 
 	taskErr := task.Prepare(context.Background())

--- a/layer1/executor/tasks/dkg/tests/dispute_gpkj_test.go
+++ b/layer1/executor/tasks/dkg/tests/dispute_gpkj_test.go
@@ -59,7 +59,7 @@ func TestGPKjDispute_NoBadGPKj(t *testing.T) {
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.EthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, len(b), int(badParticipants.Int64()))
 }
@@ -112,7 +112,7 @@ func TestGPKjDispute_TwoInvalid(t *testing.T) {
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.EthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, len(b), int(badParticipants.Int64()))
 
@@ -167,7 +167,7 @@ func TestGPKjDispute_FiveInvalid(t *testing.T) {
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.EthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, len(b), int(badParticipants.Int64()))
 

--- a/layer1/executor/tasks/dkg/tests/dispute_gpkj_test.go
+++ b/layer1/executor/tasks/dkg/tests/dispute_gpkj_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/tests"
 	"github.com/alicenet/alicenet/layer1/transaction"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +27,7 @@ func TestGPKjDispute_NoBadGPKj(t *testing.T) {
 		for j := 0; j < n; j++ {
 			disputeBadGPKjTask := suite.DisputeGPKjTasks[idx][j]
 
-			err := disputeBadGPKjTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "DisputeBadGPKjTask", "task-id", nil)
+			err := disputeBadGPKjTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "DisputeBadGPKjTask", "task-id", nil)
 			assert.Nil(t, err)
 			err = disputeBadGPKjTask.Prepare(ctx)
 			assert.Nil(t, err)
@@ -60,7 +59,7 @@ func TestGPKjDispute_NoBadGPKj(t *testing.T) {
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := ethereum.GetContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, len(b), int(badParticipants.Int64()))
 }
@@ -81,7 +80,7 @@ func TestGPKjDispute_TwoInvalid(t *testing.T) {
 		for j := 0; j < n; j++ {
 			disputeBadGPKjTask := suite.DisputeGPKjTasks[idx][j]
 
-			err := disputeBadGPKjTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "DisputeBadGPKjTask", "task-id", nil)
+			err := disputeBadGPKjTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "DisputeBadGPKjTask", "task-id", nil)
 			assert.Nil(t, err)
 			err = disputeBadGPKjTask.Prepare(ctx)
 			assert.Nil(t, err)
@@ -113,11 +112,11 @@ func TestGPKjDispute_TwoInvalid(t *testing.T) {
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := ethereum.GetContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, len(b), int(badParticipants.Int64()))
 
-	CheckBadValidators(t, b, suite)
+	CheckBadValidators(t, b, suite, fixture.Contracts)
 }
 
 // Here, we have two malicious gpkj submission.
@@ -136,7 +135,7 @@ func TestGPKjDispute_FiveInvalid(t *testing.T) {
 		for j := 0; j < n; j++ {
 			disputeBadGPKjTask := suite.DisputeGPKjTasks[idx][j]
 
-			err := disputeBadGPKjTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "DisputeBadGPKjTask", "task-id", nil)
+			err := disputeBadGPKjTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "DisputeBadGPKjTask", "task-id", nil)
 			assert.Nil(t, err)
 			err = disputeBadGPKjTask.Prepare(ctx)
 			assert.Nil(t, err)
@@ -168,9 +167,9 @@ func TestGPKjDispute_FiveInvalid(t *testing.T) {
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := ethereum.GetContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, len(b), int(badParticipants.Int64()))
 
-	CheckBadValidators(t, b, suite)
+	CheckBadValidators(t, b, suite, fixture.Contracts)
 }

--- a/layer1/executor/tasks/dkg/tests/dispute_missing_gpkj_test.go
+++ b/layer1/executor/tasks/dkg/tests/dispute_missing_gpkj_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/tests"
 	"github.com/alicenet/alicenet/layer1/transaction"
 
@@ -27,7 +26,7 @@ func TestDisputeMissingGPKjTask_Group_1_FourUnsubmittedGPKj_DoWork_Success(t *te
 	for idx := 0; idx < n; idx++ {
 		disputeMissingGPKjTask := suite.DisputeMissingGPKjTasks[idx]
 
-		err := disputeMissingGPKjTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "DisputeMissingGPKjTask", "task-id", nil)
+		err := disputeMissingGPKjTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "DisputeMissingGPKjTask", "task-id", nil)
 		assert.Nil(t, err)
 		err = disputeMissingGPKjTask.Prepare(ctx)
 		assert.Nil(t, err)
@@ -54,9 +53,9 @@ func TestDisputeMissingGPKjTask_Group_1_FourUnsubmittedGPKj_DoWork_Success(t *te
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := ethereum.GetContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, len(m), int(badParticipants.Int64()))
 
-	CheckBadValidators(t, m, suite)
+	CheckBadValidators(t, m, suite, fixture.Contracts)
 }

--- a/layer1/executor/tasks/dkg/tests/dispute_missing_gpkj_test.go
+++ b/layer1/executor/tasks/dkg/tests/dispute_missing_gpkj_test.go
@@ -53,7 +53,7 @@ func TestDisputeMissingGPKjTask_Group_1_FourUnsubmittedGPKj_DoWork_Success(t *te
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.EthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, len(m), int(badParticipants.Int64()))
 

--- a/layer1/executor/tasks/dkg/tests/dispute_missing_key_shares_test.go
+++ b/layer1/executor/tasks/dkg/tests/dispute_missing_key_shares_test.go
@@ -54,7 +54,7 @@ func TestDisputeMissingKeySharesTask_FourUnsubmittedKeyShare_DoWork_Success(t *t
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.EthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(m), badParticipants.Int64())
 }
@@ -83,7 +83,7 @@ func TestDisputeMissingKeySharesTask_NoUnSubmittedKeyShare(t *testing.T) {
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.EthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(m), badParticipants.Int64())
 }

--- a/layer1/executor/tasks/dkg/tests/dispute_missing_key_shares_test.go
+++ b/layer1/executor/tasks/dkg/tests/dispute_missing_key_shares_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/tests"
 	"github.com/alicenet/alicenet/layer1/transaction"
 
@@ -27,7 +26,7 @@ func TestDisputeMissingKeySharesTask_FourUnsubmittedKeyShare_DoWork_Success(t *t
 	for idx := 0; idx < n; idx++ {
 		disputeMissingKeyshareTask := suite.DisputeMissingKeyshareTasks[idx]
 
-		err := disputeMissingKeyshareTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "DisputeMissingKeyshareTask", "task-id", nil)
+		err := disputeMissingKeyshareTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "DisputeMissingKeyshareTask", "task-id", nil)
 		assert.Nil(t, err)
 
 		err = disputeMissingKeyshareTask.Prepare(ctx)
@@ -55,7 +54,7 @@ func TestDisputeMissingKeySharesTask_FourUnsubmittedKeyShare_DoWork_Success(t *t
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := ethereum.GetContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(m), badParticipants.Int64())
 }
@@ -72,7 +71,7 @@ func TestDisputeMissingKeySharesTask_NoUnSubmittedKeyShare(t *testing.T) {
 	// Do dispute missing key share task
 	for idx := 0; idx < n; idx++ {
 		disputeMissingKeyshareTask := suite.DisputeMissingKeyshareTasks[idx]
-		err := disputeMissingKeyshareTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "disputeMissingKeyshareTask", "task-id", nil)
+		err := disputeMissingKeyshareTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "disputeMissingKeyshareTask", "task-id", nil)
 		assert.Nil(t, err)
 		err = disputeMissingKeyshareTask.Prepare(ctx)
 		assert.Nil(t, err)
@@ -84,7 +83,7 @@ func TestDisputeMissingKeySharesTask_NoUnSubmittedKeyShare(t *testing.T) {
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := ethereum.GetContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(m), badParticipants.Int64())
 }

--- a/layer1/executor/tasks/dkg/tests/dispute_missing_registration_test.go
+++ b/layer1/executor/tasks/dkg/tests/dispute_missing_registration_test.go
@@ -53,7 +53,7 @@ func TestDisputeMissingRegistrationTask_Group_1_DoTaskSuccessOneParticipantAccus
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.EthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(d), badParticipants.Int64())
 }
@@ -99,7 +99,7 @@ func TestDisputeMissingRegistrationTask_Group_1_DoTaskSuccessThreeParticipantAcc
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.EthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(d), badParticipants.Int64())
 }
@@ -145,7 +145,7 @@ func TestDisputeMissingRegistrationTask_Group_1_DoTaskSuccessAllParticipantsAreB
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.EthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(d), badParticipants.Int64())
 }

--- a/layer1/executor/tasks/dkg/tests/dispute_missing_registration_test.go
+++ b/layer1/executor/tasks/dkg/tests/dispute_missing_registration_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/tests"
 	"github.com/alicenet/alicenet/layer1/transaction"
 
@@ -24,7 +23,7 @@ func TestDisputeMissingRegistrationTask_Group_1_DoTaskSuccessOneParticipantAccus
 
 	var receiptResponses []transaction.ReceiptResponse
 	for idx := 0; idx < n; idx++ {
-		err := suite.DispMissingRegTasks[idx].Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "DisputeMissingRegistrationTask", "task-id", nil)
+		err := suite.DispMissingRegTasks[idx].Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "DisputeMissingRegistrationTask", "task-id", nil)
 		assert.Nil(t, err)
 
 		err = suite.DispMissingRegTasks[idx].Prepare(ctx)
@@ -54,7 +53,7 @@ func TestDisputeMissingRegistrationTask_Group_1_DoTaskSuccessOneParticipantAccus
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := ethereum.GetContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(d), badParticipants.Int64())
 }
@@ -70,7 +69,7 @@ func TestDisputeMissingRegistrationTask_Group_1_DoTaskSuccessThreeParticipantAcc
 
 	var receiptResponses []transaction.ReceiptResponse
 	for idx := 0; idx < n; idx++ {
-		err := suite.DispMissingRegTasks[idx].Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "DisputeMissingRegistrationTask", "task-id", nil)
+		err := suite.DispMissingRegTasks[idx].Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "DisputeMissingRegistrationTask", "task-id", nil)
 		assert.Nil(t, err)
 
 		err = suite.DispMissingRegTasks[idx].Prepare(ctx)
@@ -100,7 +99,7 @@ func TestDisputeMissingRegistrationTask_Group_1_DoTaskSuccessThreeParticipantAcc
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := ethereum.GetContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(d), badParticipants.Int64())
 }
@@ -116,7 +115,7 @@ func TestDisputeMissingRegistrationTask_Group_1_DoTaskSuccessAllParticipantsAreB
 
 	var receiptResponses []transaction.ReceiptResponse
 	for idx := 0; idx < n; idx++ {
-		err := suite.DispMissingRegTasks[idx].Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "DisputeMissingRegistrationTask", "task-id", nil)
+		err := suite.DispMissingRegTasks[idx].Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "DisputeMissingRegistrationTask", "task-id", nil)
 		assert.Nil(t, err)
 
 		err = suite.DispMissingRegTasks[idx].Prepare(ctx)
@@ -146,7 +145,7 @@ func TestDisputeMissingRegistrationTask_Group_1_DoTaskSuccessAllParticipantsAreB
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := ethereum.GetContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(d), badParticipants.Int64())
 }

--- a/layer1/executor/tasks/dkg/tests/dispute_missing_share_distribution_test.go
+++ b/layer1/executor/tasks/dkg/tests/dispute_missing_share_distribution_test.go
@@ -55,7 +55,7 @@ func TestDisputeMissingShareDistributionTask_Group_1_ShouldAccuseOneValidatorWho
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.EthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, len(u), int(badParticipants.Uint64()))
 
@@ -105,7 +105,7 @@ func TestDisputeMissingShareDistributionTask_Group_1_ShouldAccuseAllValidatorsWh
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.EthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, len(u), int(badParticipants.Uint64()))
 
@@ -137,7 +137,7 @@ func TestDisputeMissingShareDistributionTask_Group_1_ShouldNotAccuseValidatorsWh
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.EthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, len(u), int(badParticipants.Uint64()))
 

--- a/layer1/executor/tasks/dkg/tests/dispute_missing_share_distribution_test.go
+++ b/layer1/executor/tasks/dkg/tests/dispute_missing_share_distribution_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/tests"
 	"github.com/alicenet/alicenet/layer1/transaction"
 
@@ -26,7 +25,7 @@ func TestDisputeMissingShareDistributionTask_Group_1_ShouldAccuseOneValidatorWho
 	for idx := range accounts {
 		task := suite.DisputeMissingShareDistTasks[idx]
 
-		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "DisputeMissingShareDistributionTask", "task-id", nil)
+		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "DisputeMissingShareDistributionTask", "task-id", nil)
 		assert.Nil(t, err)
 
 		err = task.Prepare(ctx)
@@ -56,11 +55,11 @@ func TestDisputeMissingShareDistributionTask_Group_1_ShouldAccuseOneValidatorWho
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := ethereum.GetContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, len(u), int(badParticipants.Uint64()))
 
-	CheckBadValidators(t, u, suite)
+	CheckBadValidators(t, u, suite, fixture.Contracts)
 }
 
 func TestDisputeMissingShareDistributionTask_Group_1_ShouldAccuseAllValidatorsWhoDidNotDistributeShares(t *testing.T) {
@@ -76,7 +75,7 @@ func TestDisputeMissingShareDistributionTask_Group_1_ShouldAccuseAllValidatorsWh
 	for idx := range accounts {
 		task := suite.DisputeMissingShareDistTasks[idx]
 
-		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "DisputeMissingShareDistributionTask", "task-id", nil)
+		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "DisputeMissingShareDistributionTask", "task-id", nil)
 		assert.Nil(t, err)
 
 		err = task.Prepare(ctx)
@@ -106,11 +105,11 @@ func TestDisputeMissingShareDistributionTask_Group_1_ShouldAccuseAllValidatorsWh
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := ethereum.GetContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, len(u), int(badParticipants.Uint64()))
 
-	CheckBadValidators(t, u, suite)
+	CheckBadValidators(t, u, suite, fixture.Contracts)
 }
 
 func TestDisputeMissingShareDistributionTask_Group_1_ShouldNotAccuseValidatorsWhoDidDistributeShares(t *testing.T) {
@@ -125,7 +124,7 @@ func TestDisputeMissingShareDistributionTask_Group_1_ShouldNotAccuseValidatorsWh
 	for idx := range accounts {
 		task := suite.DisputeMissingShareDistTasks[idx]
 
-		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "DisputeMissingShareDistributionTask", "task-id", nil)
+		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "DisputeMissingShareDistributionTask", "task-id", nil)
 		assert.Nil(t, err)
 
 		err = task.Prepare(ctx)
@@ -138,9 +137,9 @@ func TestDisputeMissingShareDistributionTask_Group_1_ShouldNotAccuseValidatorsWh
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
-	badParticipants, err := ethereum.GetContracts().Ethdkg().GetBadParticipants(callOpts)
+	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, len(u), int(badParticipants.Uint64()))
 
-	CheckBadValidators(t, u, suite)
+	CheckBadValidators(t, u, suite, fixture.Contracts)
 }

--- a/layer1/executor/tasks/dkg/tests/dispute_share_distribution_test.go
+++ b/layer1/executor/tasks/dkg/tests/dispute_share_distribution_test.go
@@ -90,7 +90,7 @@ func TestDisputeShareDistributionTask_Group_1_OneValidatorSubmittingInvalidCrede
 	callOptions, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
 	// assert no bad participants on the ETHDKG contract
-	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOptions)
+	badParticipants, err := fixture.Contracts.EthereumContracts().Ethdkg().GetBadParticipants(callOptions)
 	assert.Nil(t, err)
 	assert.Equal(t, len(b), int(badParticipants.Uint64()))
 
@@ -185,7 +185,7 @@ func TestDisputeShareDistributionTask_Group_1_TwoValidatorSubmittingInvalidCrede
 	callOptions, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
 	// assert no bad participants on the ETHDKG contract
-	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOptions)
+	badParticipants, err := fixture.Contracts.EthereumContracts().Ethdkg().GetBadParticipants(callOptions)
 	assert.Nil(t, err)
 	assert.Equal(t, len(b), int(badParticipants.Uint64()))
 
@@ -263,7 +263,7 @@ func TestDisputeShareDistributionTask_Group_1_AllValidatorSubmittingInvalidCrede
 	callOptions, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
 	// assert no bad participants on the ETHDKG contract
-	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOptions)
+	badParticipants, err := fixture.Contracts.EthereumContracts().Ethdkg().GetBadParticipants(callOptions)
 	assert.Nil(t, err)
 	// The -1 is because during the first run the validator will accuse all the participants but himself
 	// the second the rest of participants are not longer validators so they cannot accuse the first one

--- a/layer1/executor/tasks/dkg/tests/dispute_share_distribution_test.go
+++ b/layer1/executor/tasks/dkg/tests/dispute_share_distribution_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/utils"
@@ -36,7 +35,7 @@ func TestDisputeShareDistributionTask_Group_1_OneValidatorSubmittingInvalidCrede
 		for j := 0; j < n; j++ {
 			task := suite.DisputeShareDistTasks[idx][j]
 
-			err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "DisputeShareDistributionTask", "task-id", nil)
+			err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "DisputeShareDistributionTask", "task-id", nil)
 			assert.Nil(t, err)
 
 			err = task.Prepare(ctx)
@@ -91,11 +90,11 @@ func TestDisputeShareDistributionTask_Group_1_OneValidatorSubmittingInvalidCrede
 	callOptions, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
 	// assert no bad participants on the ETHDKG contract
-	badParticipants, err := ethereum.GetContracts().Ethdkg().GetBadParticipants(callOptions)
+	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOptions)
 	assert.Nil(t, err)
 	assert.Equal(t, len(b), int(badParticipants.Uint64()))
 
-	CheckBadValidators(t, b, suite)
+	CheckBadValidators(t, b, suite, fixture.Contracts)
 }
 
 // We force an error.
@@ -105,7 +104,7 @@ func TestDisputeShareDistributionTask_Group_1_Bad2(t *testing.T) {
 	db := mocks.NewTestDB()
 	log := logging.GetLogger("test").WithField("test", "test")
 
-	err := task.Initialize(context.Background(), nil, db, log, nil, "", "", nil)
+	err := task.Initialize(context.Background(), nil, db, log, nil, nil, "", "", nil)
 	assert.Nil(t, err)
 
 	taskErr := task.Prepare(context.Background())
@@ -131,7 +130,7 @@ func TestDisputeShareDistributionTask_Group_1_TwoValidatorSubmittingInvalidCrede
 		for j := 0; j < n; j++ {
 			task := suite.DisputeShareDistTasks[idx][j]
 
-			err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "DisputeShareDistributionTask", "task-id", nil)
+			err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "DisputeShareDistributionTask", "task-id", nil)
 			assert.Nil(t, err)
 
 			err = task.Prepare(ctx)
@@ -186,11 +185,11 @@ func TestDisputeShareDistributionTask_Group_1_TwoValidatorSubmittingInvalidCrede
 	callOptions, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
 	// assert no bad participants on the ETHDKG contract
-	badParticipants, err := ethereum.GetContracts().Ethdkg().GetBadParticipants(callOptions)
+	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOptions)
 	assert.Nil(t, err)
 	assert.Equal(t, len(b), int(badParticipants.Uint64()))
 
-	CheckBadValidators(t, b, suite)
+	CheckBadValidators(t, b, suite, fixture.Contracts)
 }
 
 func TestDisputeShareDistributionTask_Group_1_AllValidatorSubmittingInvalidCredentials(t *testing.T) {
@@ -208,7 +207,7 @@ func TestDisputeShareDistributionTask_Group_1_AllValidatorSubmittingInvalidCrede
 		for j := 0; j < n; j++ {
 			task := suite.DisputeShareDistTasks[idx][j]
 
-			err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "DisputeShareDistributionTask", "task-id", nil)
+			err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "DisputeShareDistributionTask", "task-id", nil)
 			assert.Nil(t, err)
 
 			err = task.Prepare(ctx)
@@ -264,7 +263,7 @@ func TestDisputeShareDistributionTask_Group_1_AllValidatorSubmittingInvalidCrede
 	callOptions, err := suite.Eth.GetCallOpts(ctx, accounts[0])
 	assert.Nil(t, err)
 	// assert no bad participants on the ETHDKG contract
-	badParticipants, err := ethereum.GetContracts().Ethdkg().GetBadParticipants(callOptions)
+	badParticipants, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetBadParticipants(callOptions)
 	assert.Nil(t, err)
 	// The -1 is because during the first run the validator will accuse all the participants but himself
 	// the second the rest of participants are not longer validators so they cannot accuse the first one

--- a/layer1/executor/tasks/dkg/tests/gpkj_submission_test.go
+++ b/layer1/executor/tasks/dkg/tests/gpkj_submission_test.go
@@ -53,7 +53,7 @@ func TestGPKjSubmission_Group_1_GoodAllValid(t *testing.T) {
 	for idx, acct := range accounts {
 		callOpts, err := eth.GetCallOpts(context.Background(), acct)
 		assert.Nil(t, err)
-		p, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
+		p, err := fixture.Contracts.EthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
 		assert.Nil(t, err)
 
 		dkgState, err := state.GetDkgState(suite.DKGStatesDbs[idx])

--- a/layer1/executor/tasks/dkg/tests/gpkj_submission_test.go
+++ b/layer1/executor/tasks/dkg/tests/gpkj_submission_test.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/alicenet/alicenet/layer1/tests"
@@ -30,7 +29,7 @@ func TestGPKjSubmission_Group_1_GoodAllValid(t *testing.T) {
 	var receiptResponses []transaction.ReceiptResponse
 	for idx := 0; idx < n; idx++ {
 		gpkjSubmissionTask := suite.GpkjSubmissionTasks[idx]
-		err := gpkjSubmissionTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "GpkjSubmissionTask", "tak-id", nil)
+		err := gpkjSubmissionTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "GpkjSubmissionTask", "tak-id", nil)
 		assert.Nil(t, err)
 		err = gpkjSubmissionTask.Prepare(ctx)
 		assert.Nil(t, err)
@@ -54,7 +53,7 @@ func TestGPKjSubmission_Group_1_GoodAllValid(t *testing.T) {
 	for idx, acct := range accounts {
 		callOpts, err := eth.GetCallOpts(context.Background(), acct)
 		assert.Nil(t, err)
-		p, err := ethereum.GetContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
+		p, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
 		assert.Nil(t, err)
 
 		dkgState, err := state.GetDkgState(suite.DKGStatesDbs[idx])
@@ -77,7 +76,7 @@ func TestGPKjSubmission_Group_1_Bad1(t *testing.T) {
 	dkgState, err := state.GetDkgState(suite.DKGStatesDbs[0])
 	assert.Nil(t, err)
 	task := suite.GpkjSubmissionTasks[0]
-	err = task.Initialize(ctx, nil, suite.DKGStatesDbs[0], fixture.Logger, suite.Eth, "GpkjSubmissionTask", "task-id", nil)
+	err = task.Initialize(ctx, nil, suite.DKGStatesDbs[0], fixture.Logger, suite.Eth, fixture.Contracts, "GpkjSubmissionTask", "task-id", nil)
 	assert.Nil(t, err)
 
 	err = task.Prepare(ctx)
@@ -100,7 +99,7 @@ func TestGPKjSubmission_Group_1_Bad2(t *testing.T) {
 	db := mocks.NewTestDB()
 	log := logging.GetLogger("test").WithField("test", "test")
 
-	err := task.Initialize(context.Background(), nil, db, log, nil, "", "", nil)
+	err := task.Initialize(context.Background(), nil, db, log, nil, nil, "", "", nil)
 	assert.Nil(t, err)
 
 	taskErr := task.Prepare(context.Background())
@@ -123,7 +122,7 @@ func TestGPKjSubmission_Group_1_Bad3(t *testing.T) {
 	assert.Nil(t, err)
 
 	task := suite.GpkjSubmissionTasks[0]
-	err = task.Initialize(ctx, nil, suite.DKGStatesDbs[0], fixture.Logger, suite.Eth, "GpkjSubmissionTask", "task-id", nil)
+	err = task.Initialize(ctx, nil, suite.DKGStatesDbs[0], fixture.Logger, suite.Eth, fixture.Contracts, "GpkjSubmissionTask", "task-id", nil)
 	assert.Nil(t, err)
 
 	taskErr := task.Prepare(ctx)
@@ -157,7 +156,7 @@ func TestGPKjSubmission_Group_2_Bad4(t *testing.T) {
 	tasksVec := suite.GpkjSubmissionTasks
 	for idx := 0; idx < n; idx++ {
 		gpkjSubmissionTask := suite.GpkjSubmissionTasks[idx]
-		err := gpkjSubmissionTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "GpkjSubmissionTask", "tak-id", nil)
+		err := gpkjSubmissionTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "GpkjSubmissionTask", "tak-id", nil)
 		assert.Nil(t, err)
 		err = gpkjSubmissionTask.Prepare(ctx)
 		assert.Nil(t, err)

--- a/layer1/executor/tasks/dkg/tests/keyshare_submission_test.go
+++ b/layer1/executor/tasks/dkg/tests/keyshare_submission_test.go
@@ -27,7 +27,7 @@ func TestKeyShareSubmission_GoodAllValid(t *testing.T) {
 		dkgState, err := state.GetDkgState(suite.DKGStatesDbs[idx])
 		assert.Nil(t, err)
 
-		p, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
+		p, err := fixture.Contracts.EthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
 		assert.Nil(t, err)
 
 		// check points
@@ -38,7 +38,7 @@ func TestKeyShareSubmission_GoodAllValid(t *testing.T) {
 	}
 
 	// assert that ETHDKG is at MPKSubmission phase
-	phase, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetETHDKGPhase(callOpts)
+	phase, err := fixture.Contracts.EthereumContracts().Ethdkg().GetETHDKGPhase(callOpts)
 	assert.Nil(t, err)
 
 	assert.Equal(t, uint8(state.MPKSubmission), phase)

--- a/layer1/executor/tasks/dkg/tests/keyshare_submission_test.go
+++ b/layer1/executor/tasks/dkg/tests/keyshare_submission_test.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,7 +27,7 @@ func TestKeyShareSubmission_GoodAllValid(t *testing.T) {
 		dkgState, err := state.GetDkgState(suite.DKGStatesDbs[idx])
 		assert.Nil(t, err)
 
-		p, err := ethereum.GetContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
+		p, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
 		assert.Nil(t, err)
 
 		// check points
@@ -39,7 +38,7 @@ func TestKeyShareSubmission_GoodAllValid(t *testing.T) {
 	}
 
 	// assert that ETHDKG is at MPKSubmission phase
-	phase, err := ethereum.GetContracts().Ethdkg().GetETHDKGPhase(callOpts)
+	phase, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetETHDKGPhase(callOpts)
 	assert.Nil(t, err)
 
 	assert.Equal(t, uint8(state.MPKSubmission), phase)
@@ -65,7 +64,7 @@ func TestKeyShareSubmission_Bad3(t *testing.T) {
 		assert.Nil(t, err)
 		keyshareSubmissionTask := suite.KeyshareSubmissionTasks[idx]
 
-		err = keyshareSubmissionTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "KeyShareSubmissionTask", "task-id", nil)
+		err = keyshareSubmissionTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "KeyShareSubmissionTask", "task-id", nil)
 		assert.Nil(t, err)
 		err = keyshareSubmissionTask.Prepare(ctx)
 		assert.NotNil(t, err)
@@ -85,7 +84,7 @@ func TestKeyShareSubmission_Bad4(t *testing.T) {
 	// Do key share submission task
 	for idx := 0; idx < n; idx++ {
 		keyshareSubmissionTask := suite.KeyshareSubmissionTasks[idx]
-		err := keyshareSubmissionTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "KeyShareSubmissionTask", "task-id", nil)
+		err := keyshareSubmissionTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "KeyShareSubmissionTask", "task-id", nil)
 		assert.Nil(t, err)
 		err = keyshareSubmissionTask.Prepare(ctx)
 		assert.Nil(t, err)

--- a/layer1/executor/tasks/dkg/tests/mpk_submission_test.go
+++ b/layer1/executor/tasks/dkg/tests/mpk_submission_test.go
@@ -61,7 +61,7 @@ func TestMPKSubmission_Group_1_GoodAllValid(t *testing.T) {
 	for idx, acct := range accounts {
 		callOpts, err := eth.GetCallOpts(context.Background(), acct)
 		assert.Nil(t, err)
-		isMPKSet, err := fixture.Contracts.GetEthereumContracts().Ethdkg().IsMasterPublicKeySet(callOpts)
+		isMPKSet, err := fixture.Contracts.EthereumContracts().Ethdkg().IsMasterPublicKeySet(callOpts)
 		assert.Nil(t, err)
 		assert.True(t, isMPKSet)
 

--- a/layer1/executor/tasks/dkg/tests/mpk_submission_test.go
+++ b/layer1/executor/tasks/dkg/tests/mpk_submission_test.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/utils"
@@ -32,7 +31,7 @@ func TestMPKSubmission_Group_1_GoodAllValid(t *testing.T) {
 	for idx := 0; idx < n; idx++ {
 
 		mpkSubmissionTask := suite.MpkSubmissionTasks[idx]
-		err := mpkSubmissionTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "MpkSubmissionTasks", "tak-id", nil)
+		err := mpkSubmissionTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "MpkSubmissionTasks", "tak-id", nil)
 		assert.Nil(t, err)
 		err = mpkSubmissionTask.Prepare(ctx)
 		assert.Nil(t, err)
@@ -62,7 +61,7 @@ func TestMPKSubmission_Group_1_GoodAllValid(t *testing.T) {
 	for idx, acct := range accounts {
 		callOpts, err := eth.GetCallOpts(context.Background(), acct)
 		assert.Nil(t, err)
-		isMPKSet, err := ethereum.GetContracts().Ethdkg().IsMasterPublicKeySet(callOpts)
+		isMPKSet, err := fixture.Contracts.GetEthereumContracts().Ethdkg().IsMasterPublicKeySet(callOpts)
 		assert.Nil(t, err)
 		assert.True(t, isMPKSet)
 
@@ -101,7 +100,7 @@ func TestMPKSubmission_Group_1_Bad1(t *testing.T) {
 	dkgState, err := state.GetDkgState(suite.DKGStatesDbs[0])
 	assert.Nil(t, err)
 	task := suite.MpkSubmissionTasks[0]
-	err = task.Initialize(ctx, nil, suite.DKGStatesDbs[0], fixture.Logger, suite.Eth, "MPKSubmissionTask", "task-id", nil)
+	err = task.Initialize(ctx, nil, suite.DKGStatesDbs[0], fixture.Logger, suite.Eth, fixture.Contracts, "MPKSubmissionTask", "task-id", nil)
 	assert.Nil(t, err)
 
 	err = task.Prepare(ctx)
@@ -123,7 +122,7 @@ func TestMPKSubmission_Group_1_Bad2(t *testing.T) {
 	db := mocks.NewTestDB()
 	log := logging.GetLogger("test").WithField("test", "test")
 
-	err := task.Initialize(context.Background(), nil, db, log, nil, "", "", nil)
+	err := task.Initialize(context.Background(), nil, db, log, nil, nil, "", "", nil)
 	assert.Nil(t, err)
 
 	taskErr := task.Prepare(context.Background())
@@ -147,7 +146,7 @@ func TestMPKSubmission_Group_2_Bad4(t *testing.T) {
 	assert.Nil(t, err)
 
 	task := suite.MpkSubmissionTasks[0]
-	err = task.Initialize(ctx, nil, suite.DKGStatesDbs[0], fixture.Logger, suite.Eth, "MPKSubmissionTask", "task-id", nil)
+	err = task.Initialize(ctx, nil, suite.DKGStatesDbs[0], fixture.Logger, suite.Eth, fixture.Contracts, "MPKSubmissionTask", "task-id", nil)
 	assert.Nil(t, err)
 
 	taskErr := task.Prepare(ctx)
@@ -167,7 +166,7 @@ func TestMPKSubmission_Group_2_LeaderElection(t *testing.T) {
 		assert.Nil(t, err)
 
 		task := suite.MpkSubmissionTasks[idx]
-		err = task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "MPKSubmissionTask", "task-id", nil)
+		err = task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "MPKSubmissionTask", "task-id", nil)
 		assert.Nil(t, err)
 
 		err = task.Prepare(ctx)

--- a/layer1/executor/tasks/dkg/tests/register_test.go
+++ b/layer1/executor/tasks/dkg/tests/register_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/alicenet/alicenet/consensus/db"
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/tests/utils"
@@ -29,7 +28,7 @@ func TestRegisterTask_Group_1_Task(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	c := ethereum.GetContracts()
+	c := fixture.Contracts.GetEthereumContracts()
 
 	// Check status
 	callOpts, err := eth.GetCallOpts(ctx, acct)
@@ -61,7 +60,7 @@ func TestRegisterTask_Group_1_Task(t *testing.T) {
 	fixture.Logger.Debugf("Kicking off EthDKG used %v gas", rcpt.GasUsed)
 	fixture.Logger.Debugf("registration opens:%v", rcpt.BlockNumber)
 
-	openEvent, err := utils.GetETHDKGRegistrationOpened(rcpt.Logs, eth)
+	openEvent, err := utils.GetETHDKGRegistrationOpened(rcpt.Logs, eth, fixture.Contracts)
 	assert.Nil(t, err)
 	assert.NotNil(t, openEvent)
 
@@ -88,7 +87,7 @@ func TestRegisterTask_Group_1_Task(t *testing.T) {
 	dkgDb := GetDKGDb(t)
 	err = state.SaveDkgState(dkgDb, dkgState)
 	assert.Nil(t, err)
-	err = registrationTask.Initialize(ctx, nil, dkgDb, fixture.Logger, eth, "RegistrationTask", "task-id", nil)
+	err = registrationTask.Initialize(ctx, nil, dkgDb, fixture.Logger, eth, fixture.Contracts, "RegistrationTask", "task-id", nil)
 	assert.Nil(t, err)
 	err = registrationTask.Prepare(ctx)
 	assert.Nil(t, err)
@@ -123,7 +122,7 @@ func TestRegisterTask_Group_1_Good2(t *testing.T) {
 
 	fixture.Logger.Debugf("Updating phase length used %v gas vs %v", rcpt.GasUsed, txn.Gas())
 
-	event, err := utils.GetETHDKGRegistrationOpened(rcpt.Logs, eth)
+	event, err := utils.GetETHDKGRegistrationOpened(rcpt.Logs, eth, fixture.Contracts)
 	assert.Nil(t, err)
 	assert.NotNil(t, event)
 
@@ -155,7 +154,7 @@ func TestRegisterTask_Group_1_Good2(t *testing.T) {
 		dkgStatesDbs[idx] = dkgDb
 		tasksVec[idx] = registrationTask
 
-		err = tasksVec[idx].Initialize(ctx, nil, dkgDb, fixture.Logger, eth, "RegistrationTask", "task-id", nil)
+		err = tasksVec[idx].Initialize(ctx, nil, dkgDb, fixture.Logger, eth, fixture.Contracts, "RegistrationTask", "task-id", nil)
 		assert.Nil(t, err)
 		err = tasksVec[idx].Prepare(ctx)
 		assert.Nil(t, err)
@@ -168,7 +167,7 @@ func TestRegisterTask_Group_1_Good2(t *testing.T) {
 	for idx, acct := range accounts {
 		callOpts, err := eth.GetCallOpts(context.Background(), acct)
 		assert.Nil(t, err)
-		p, err := ethereum.GetContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
+		p, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
 		assert.Nil(t, err)
 
 		dkgState, err := state.GetDkgState(dkgStatesDbs[idx])
@@ -205,7 +204,7 @@ func TestRegisterTask_Group_1_Bad1(t *testing.T) {
 	_, rcpt, err := InitializeETHDKG(fixture, ownerOpts, ctx)
 	assert.Nil(t, err)
 
-	event, err := utils.GetETHDKGRegistrationOpened(rcpt.Logs, eth)
+	event, err := utils.GetETHDKGRegistrationOpened(rcpt.Logs, eth, fixture.Contracts)
 	assert.Nil(t, err)
 	assert.NotNil(t, event)
 
@@ -232,7 +231,7 @@ func TestRegisterTask_Group_1_Bad1(t *testing.T) {
 	dkgDb := GetDKGDb(t)
 	err = state.SaveDkgState(dkgDb, dkgState)
 	assert.Nil(t, err)
-	err = registrationTask.Initialize(ctx, nil, dkgDb, fixture.Logger, eth, "RegistrationTask", "task-id", nil)
+	err = registrationTask.Initialize(ctx, nil, dkgDb, fixture.Logger, eth, fixture.Contracts, "RegistrationTask", "task-id", nil)
 	assert.Nil(t, err)
 	err = registrationTask.Prepare(ctx)
 	assert.Nil(t, err)
@@ -265,7 +264,7 @@ func TestRegisterTask_Group_2_Bad2(t *testing.T) {
 	_, rcpt, err := InitializeETHDKG(fixture, ownerOpts, ctx)
 	assert.Nil(t, err)
 
-	event, err := utils.GetETHDKGRegistrationOpened(rcpt.Logs, eth)
+	event, err := utils.GetETHDKGRegistrationOpened(rcpt.Logs, eth, fixture.Contracts)
 	assert.Nil(t, err)
 	assert.NotNil(t, event)
 
@@ -292,7 +291,7 @@ func TestRegisterTask_Group_2_Bad2(t *testing.T) {
 	dkgDb := GetDKGDb(t)
 	err = state.SaveDkgState(dkgDb, dkgState)
 	assert.Nil(t, err)
-	err = registrationTask.Initialize(ctx, nil, dkgDb, fixture.Logger, eth, "RegistrationTask", "task-id", nil)
+	err = registrationTask.Initialize(ctx, nil, dkgDb, fixture.Logger, eth, fixture.Contracts, "RegistrationTask", "task-id", nil)
 	assert.Nil(t, err)
 	err = registrationTask.Prepare(ctx)
 	assert.Nil(t, err)
@@ -350,7 +349,7 @@ func TestRegisterTask_Group_2_Bad5(t *testing.T) {
 	_, rcpt, err := InitializeETHDKG(fixture, ownerOpts, ctx)
 	assert.Nil(t, err)
 
-	event, err := utils.GetETHDKGRegistrationOpened(rcpt.Logs, eth)
+	event, err := utils.GetETHDKGRegistrationOpened(rcpt.Logs, eth, fixture.Contracts)
 	assert.Nil(t, err)
 	assert.NotNil(t, event)
 
@@ -380,7 +379,7 @@ func TestRegisterTask_Group_2_Bad5(t *testing.T) {
 	dkgDb := GetDKGDb(t)
 	err = state.SaveDkgState(dkgDb, dkgState)
 	assert.Nil(t, err)
-	err = registrationTask.Initialize(ctx, nil, dkgDb, fixture.Logger, eth, "RegistrationTask", "task-id", nil)
+	err = registrationTask.Initialize(ctx, nil, dkgDb, fixture.Logger, eth, fixture.Contracts, "RegistrationTask", "task-id", nil)
 	assert.Nil(t, err)
 	err = registrationTask.Prepare(ctx)
 	assert.Nil(t, err)
@@ -401,7 +400,7 @@ func TestRegisterTask_Group_3_ShouldRetryFalse(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	c := ethereum.GetContracts()
+	c := fixture.Contracts.GetEthereumContracts()
 	tests.MineFinalityDelayBlocks(eth)
 	// Check status
 	callOpts, err := eth.GetCallOpts(ctx, acct)
@@ -428,7 +427,7 @@ func TestRegisterTask_Group_3_ShouldRetryFalse(t *testing.T) {
 	fixture.Logger.Debugf("Kicking off EthDKG used %v gas", rcpt.GasUsed)
 	fixture.Logger.Debugf("registration opens:%v", rcpt.BlockNumber)
 
-	openEvent, err := utils.GetETHDKGRegistrationOpened(rcpt.Logs, eth)
+	openEvent, err := utils.GetETHDKGRegistrationOpened(rcpt.Logs, eth, fixture.Contracts)
 	assert.Nil(t, err)
 	assert.NotNil(t, openEvent)
 
@@ -455,7 +454,7 @@ func TestRegisterTask_Group_3_ShouldRetryFalse(t *testing.T) {
 	dkgDb := GetDKGDb(t)
 	err = state.SaveDkgState(dkgDb, dkgState)
 	assert.Nil(t, err)
-	err = registrationTask.Initialize(ctx, nil, dkgDb, fixture.Logger, eth, "RegistrationTask", "task-id", nil)
+	err = registrationTask.Initialize(ctx, nil, dkgDb, fixture.Logger, eth, fixture.Contracts, "RegistrationTask", "task-id", nil)
 	assert.Nil(t, err)
 	err = registrationTask.Prepare(ctx)
 	assert.Nil(t, err)
@@ -483,7 +482,7 @@ func TestRegisterTask_Group_3_ShouldRetryTrue(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	c := ethereum.GetContracts()
+	c := fixture.Contracts.GetEthereumContracts()
 
 	// Check status
 	callOpts, err := eth.GetCallOpts(ctx, acct)
@@ -514,7 +513,7 @@ func TestRegisterTask_Group_3_ShouldRetryTrue(t *testing.T) {
 	fixture.Logger.Debugf("Kicking off EthDKG used %v gas", rcpt.GasUsed)
 	fixture.Logger.Debugf("registration opens:%v", rcpt.BlockNumber)
 
-	openEvent, err := utils.GetETHDKGRegistrationOpened(rcpt.Logs, eth)
+	openEvent, err := utils.GetETHDKGRegistrationOpened(rcpt.Logs, eth, fixture.Contracts)
 	assert.Nil(t, err)
 	assert.NotNil(t, openEvent)
 
@@ -541,7 +540,7 @@ func TestRegisterTask_Group_3_ShouldRetryTrue(t *testing.T) {
 	dkgDb := GetDKGDb(t)
 	err = state.SaveDkgState(dkgDb, dkgState)
 	assert.Nil(t, err)
-	err = registrationTask.Initialize(ctx, nil, dkgDb, fixture.Logger, eth, "RegistrationTask", "task-id", nil)
+	err = registrationTask.Initialize(ctx, nil, dkgDb, fixture.Logger, eth, fixture.Contracts, "RegistrationTask", "task-id", nil)
 	assert.Nil(t, err)
 	err = registrationTask.Prepare(ctx)
 

--- a/layer1/executor/tasks/dkg/tests/register_test.go
+++ b/layer1/executor/tasks/dkg/tests/register_test.go
@@ -28,7 +28,7 @@ func TestRegisterTask_Group_1_Task(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	c := fixture.Contracts.GetEthereumContracts()
+	c := fixture.Contracts.EthereumContracts()
 
 	// Check status
 	callOpts, err := eth.GetCallOpts(ctx, acct)
@@ -167,7 +167,7 @@ func TestRegisterTask_Group_1_Good2(t *testing.T) {
 	for idx, acct := range accounts {
 		callOpts, err := eth.GetCallOpts(context.Background(), acct)
 		assert.Nil(t, err)
-		p, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
+		p, err := fixture.Contracts.EthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
 		assert.Nil(t, err)
 
 		dkgState, err := state.GetDkgState(dkgStatesDbs[idx])
@@ -400,7 +400,7 @@ func TestRegisterTask_Group_3_ShouldRetryFalse(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	c := fixture.Contracts.GetEthereumContracts()
+	c := fixture.Contracts.EthereumContracts()
 	tests.MineFinalityDelayBlocks(eth)
 	// Check status
 	callOpts, err := eth.GetCallOpts(ctx, acct)
@@ -482,7 +482,7 @@ func TestRegisterTask_Group_3_ShouldRetryTrue(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	c := fixture.Contracts.GetEthereumContracts()
+	c := fixture.Contracts.EthereumContracts()
 
 	// Check status
 	callOpts, err := eth.GetCallOpts(ctx, acct)

--- a/layer1/executor/tasks/dkg/tests/setup_test.go
+++ b/layer1/executor/tasks/dkg/tests/setup_test.go
@@ -123,7 +123,7 @@ func SetETHDKGPhaseLength(length uint16, fixture *tests.ClientFixture, callOpts 
 		return nil, nil, err
 	}
 
-	txn, err := fixture.Contracts.GetEthereumContracts().ContractFactory().CallAny(callOpts, fixture.Contracts.GetEthereumContracts().EthdkgAddress(), big.NewInt(0), input)
+	txn, err := fixture.Contracts.EthereumContracts().ContractFactory().CallAny(callOpts, fixture.Contracts.EthereumContracts().EthdkgAddress(), big.NewInt(0), input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -150,7 +150,7 @@ func InitializeETHDKG(fixture *tests.ClientFixture, callOpts *bind.TransactOpts,
 		return nil, nil, err
 	}
 
-	txn, err := fixture.Contracts.GetEthereumContracts().ContractFactory().CallAny(callOpts, fixture.Contracts.GetEthereumContracts().ValidatorPoolAddress(), big.NewInt(0), input)
+	txn, err := fixture.Contracts.EthereumContracts().ContractFactory().CallAny(callOpts, fixture.Contracts.EthereumContracts().ValidatorPoolAddress(), big.NewInt(0), input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -196,12 +196,12 @@ func StartFromRegistrationOpenPhase(t *testing.T, fixture *tests.ClientFixture, 
 		validatorAddresses = append(validatorAddresses, acc.Address)
 	}
 
-	phase, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetETHDKGPhase(callOpts)
+	phase, err := fixture.Contracts.EthereumContracts().Ethdkg().GetETHDKGPhase(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, uint8(state.RegistrationOpen), phase)
 
 	n := len(validatorAddresses)
-	valCount, err := fixture.Contracts.GetEthereumContracts().ValidatorPool().GetValidatorsCount(callOpts)
+	valCount, err := fixture.Contracts.EthereumContracts().ValidatorPool().GetValidatorsCount(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, uint64(n), valCount.Uint64())
 
@@ -316,7 +316,7 @@ func StartFromShareDistributionPhase(t *testing.T, fixture *tests.ClientFixture,
 
 	callOpts, err := suite.Eth.GetCallOpts(ctx, suite.Eth.GetDefaultAccount())
 	assert.Nil(t, err)
-	phase, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetETHDKGPhase(callOpts)
+	phase, err := fixture.Contracts.EthereumContracts().Ethdkg().GetETHDKGPhase(callOpts)
 	assert.Nil(t, err)
 	assert.Equal(t, phase, uint8(state.ShareDistribution))
 
@@ -709,7 +709,7 @@ func CheckBadValidators(t *testing.T, badValidators []int, suite *TestSuite, con
 		callOpts, err := suite.Eth.GetCallOpts(context.Background(), dkgState.Account)
 		assert.Nil(t, err)
 
-		isValidator, err := contracts.GetEthereumContracts().ValidatorPool().IsValidator(callOpts, dkgState.Account.Address)
+		isValidator, err := contracts.EthereumContracts().ValidatorPool().IsValidator(callOpts, dkgState.Account.Address)
 		assert.Nil(t, err)
 		assert.Equal(t, false, isValidator)
 	}

--- a/layer1/executor/tasks/dkg/tests/share_distribution_test.go
+++ b/layer1/executor/tasks/dkg/tests/share_distribution_test.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/alicenet/alicenet/layer1/tests"
@@ -30,7 +29,7 @@ func TestShareDistribution_Group_1_Good(t *testing.T) {
 
 		shareDistributionTask := suite.ShareDistTasks[idx]
 
-		err := shareDistributionTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], logger, suite.Eth, "ShareDistributionTask", "task-id", nil)
+		err := shareDistributionTask.Initialize(ctx, nil, suite.DKGStatesDbs[idx], logger, suite.Eth, fixture.Contracts, "ShareDistributionTask", "task-id", nil)
 		assert.Nil(t, err)
 		err = shareDistributionTask.Prepare(ctx)
 		assert.Nil(t, err)
@@ -53,7 +52,7 @@ func TestShareDistribution_Group_1_Bad1(t *testing.T) {
 	for idx, acct := range accounts {
 		callOpts, err := suite.Eth.GetCallOpts(context.Background(), acct)
 		assert.Nil(t, err)
-		p, err := ethereum.GetContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
+		p, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
 		assert.Nil(t, err)
 
 		dkgState, err := state.GetDkgState(suite.DKGStatesDbs[idx])
@@ -68,7 +67,7 @@ func TestShareDistribution_Group_1_Bad1(t *testing.T) {
 	badIdx := n - 2
 	for idx := 0; idx < n; idx++ {
 		task := suite.ShareDistTasks[idx]
-		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "ShareDistributionTask", "task-id", nil)
+		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "ShareDistributionTask", "task-id", nil)
 		assert.Nil(t, err)
 		err = task.Prepare(ctx)
 		assert.Nil(t, err)
@@ -108,7 +107,7 @@ func TestShareDistribution_Group_1_Bad2(t *testing.T) {
 	for idx, acct := range accounts {
 		callOpts, err := suite.Eth.GetCallOpts(context.Background(), acct)
 		assert.Nil(t, err)
-		p, err := ethereum.GetContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
+		p, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
 		assert.Nil(t, err)
 
 		dkgState, err := state.GetDkgState(suite.DKGStatesDbs[idx])
@@ -123,7 +122,7 @@ func TestShareDistribution_Group_1_Bad2(t *testing.T) {
 	badIdx := n - 1
 	for idx := 0; idx < n; idx++ {
 		task := suite.ShareDistTasks[idx]
-		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "ShareDistributionTask", "task-id", nil)
+		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "ShareDistributionTask", "task-id", nil)
 		assert.Nil(t, err)
 		err = task.Prepare(ctx)
 		assert.Nil(t, err)
@@ -166,7 +165,7 @@ func TestShareDistribution_Group_2_Bad4(t *testing.T) {
 	for idx, acct := range accounts {
 		callOpts, err := eth.GetCallOpts(context.Background(), acct)
 		assert.Nil(t, err)
-		p, err := ethereum.GetContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
+		p, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
 		assert.Nil(t, err)
 
 		dkgState, err := state.GetDkgState(suite.DKGStatesDbs[idx])
@@ -181,7 +180,7 @@ func TestShareDistribution_Group_2_Bad4(t *testing.T) {
 	badCommitmentIdx := n - 3
 	for idx := 0; idx < n; idx++ {
 		task := suite.ShareDistTasks[idx]
-		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "ShareDistributionTask", "task-id", nil)
+		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "ShareDistributionTask", "task-id", nil)
 		assert.Nil(t, err)
 		err = task.Prepare(ctx)
 		assert.Nil(t, err)
@@ -222,7 +221,7 @@ func TestShareDistribution_Group_2_Bad5(t *testing.T) {
 	badShareIdx := n - 2
 	for idx := 0; idx < n; idx++ {
 		task := suite.ShareDistTasks[idx]
-		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "ShareDistributionTask", "task-id", nil)
+		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "ShareDistributionTask", "task-id", nil)
 		assert.Nil(t, err)
 		err = task.Prepare(ctx)
 		assert.Nil(t, err)
@@ -266,7 +265,7 @@ func TestShareDistribution_Group_2_Bad6(t *testing.T) {
 	err := state.SaveDkgState(dkgDb, dkgState)
 	assert.Nil(t, err)
 	task := dkg.NewShareDistributionTask(dkgState.PhaseStart, dkgState.PhaseStart+dkgState.PhaseLength)
-	err = task.Initialize(ctx, nil, dkgDb, fixture.Logger, eth, "ShareDistributionTask", "task-id", nil)
+	err = task.Initialize(ctx, nil, dkgDb, fixture.Logger, eth, fixture.Contracts, "ShareDistributionTask", "task-id", nil)
 	assert.Nil(t, err)
 	err = task.Prepare(ctx)
 	assert.NotNil(t, err)
@@ -281,7 +280,7 @@ func TestShareDistribution_Group_3_ShouldRetryTrue(t *testing.T) {
 	// Do Share Distribution task
 	for idx := 0; idx < n; idx++ {
 		task := suite.ShareDistTasks[idx]
-		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "ShareDistributionTask", "task-id", nil)
+		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "ShareDistributionTask", "task-id", nil)
 		assert.Nil(t, err)
 		err = task.Prepare(ctx)
 		assert.Nil(t, err)
@@ -301,7 +300,7 @@ func TestShareDistribution_Group_3_ShouldRetryFalse(t *testing.T) {
 	// Do Share Distribution task
 	for idx := 0; idx < n; idx++ {
 		task := suite.ShareDistTasks[idx]
-		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, "ShareDistributionTask", "task-id", nil)
+		err := task.Initialize(ctx, nil, suite.DKGStatesDbs[idx], fixture.Logger, suite.Eth, fixture.Contracts, "ShareDistributionTask", "task-id", nil)
 		assert.Nil(t, err)
 		err = task.Prepare(ctx)
 		assert.Nil(t, err)

--- a/layer1/executor/tasks/dkg/tests/share_distribution_test.go
+++ b/layer1/executor/tasks/dkg/tests/share_distribution_test.go
@@ -52,7 +52,7 @@ func TestShareDistribution_Group_1_Bad1(t *testing.T) {
 	for idx, acct := range accounts {
 		callOpts, err := suite.Eth.GetCallOpts(context.Background(), acct)
 		assert.Nil(t, err)
-		p, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
+		p, err := fixture.Contracts.EthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
 		assert.Nil(t, err)
 
 		dkgState, err := state.GetDkgState(suite.DKGStatesDbs[idx])
@@ -107,7 +107,7 @@ func TestShareDistribution_Group_1_Bad2(t *testing.T) {
 	for idx, acct := range accounts {
 		callOpts, err := suite.Eth.GetCallOpts(context.Background(), acct)
 		assert.Nil(t, err)
-		p, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
+		p, err := fixture.Contracts.EthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
 		assert.Nil(t, err)
 
 		dkgState, err := state.GetDkgState(suite.DKGStatesDbs[idx])
@@ -165,7 +165,7 @@ func TestShareDistribution_Group_2_Bad4(t *testing.T) {
 	for idx, acct := range accounts {
 		callOpts, err := eth.GetCallOpts(context.Background(), acct)
 		assert.Nil(t, err)
-		p, err := fixture.Contracts.GetEthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
+		p, err := fixture.Contracts.EthereumContracts().Ethdkg().GetParticipantInternalState(callOpts, acct.Address)
 		assert.Nil(t, err)
 
 		dkgState, err := state.GetDkgState(suite.DKGStatesDbs[idx])

--- a/layer1/executor/tasks/dkg/tests/utils/setup.go
+++ b/layer1/executor/tasks/dkg/tests/utils/setup.go
@@ -10,7 +10,6 @@ import (
 	"github.com/alicenet/alicenet/crypto/bn256"
 	"github.com/alicenet/alicenet/crypto/bn256/cloudflare"
 	"github.com/alicenet/alicenet/layer1"
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/alicenet/alicenet/layer1/monitor/events"
 	"github.com/alicenet/alicenet/layer1/tests"
@@ -265,7 +264,7 @@ func GenerateGPKJ(dkgStates []*state.DkgState) {
 	}
 }
 
-func GetETHDKGRegistrationOpened(logs []*types.Log, eth layer1.Client) (*bindings.ETHDKGRegistrationOpened, error) {
+func GetETHDKGRegistrationOpened(logs []*types.Log, eth layer1.Client, contracts layer1.AllSmartContracts) (*bindings.ETHDKGRegistrationOpened, error) {
 	eventMap := events.GetETHDKGEvents()
 	eventInfo, ok := eventMap["RegistrationOpened"]
 	if !ok {
@@ -277,7 +276,7 @@ func GetETHDKGRegistrationOpened(logs []*types.Log, eth layer1.Client) (*binding
 	for _, log := range logs {
 		for _, topic := range log.Topics {
 			if topic.String() == eventInfo.ID.String() {
-				event, err = ethereum.GetContracts().Ethdkg().ParseRegistrationOpened(*log)
+				event, err = contracts.GetEthereumContracts().Ethdkg().ParseRegistrationOpened(*log)
 				if err != nil {
 					continue
 				}

--- a/layer1/executor/tasks/dkg/tests/utils/setup.go
+++ b/layer1/executor/tasks/dkg/tests/utils/setup.go
@@ -276,7 +276,7 @@ func GetETHDKGRegistrationOpened(logs []*types.Log, eth layer1.Client, contracts
 	for _, log := range logs {
 		for _, topic := range log.Topics {
 			if topic.String() == eventInfo.ID.String() {
-				event, err = contracts.GetEthereumContracts().Ethdkg().ParseRegistrationOpened(*log)
+				event, err = contracts.EthereumContracts().Ethdkg().ParseRegistrationOpened(*log)
 				if err != nil {
 					continue
 				}

--- a/layer1/executor/tasks/dkg/utils/utils.go
+++ b/layer1/executor/tasks/dkg/utils/utils.go
@@ -10,7 +10,6 @@ import (
 	"github.com/alicenet/alicenet/consensus/db"
 	"github.com/alicenet/alicenet/constants"
 	"github.com/alicenet/alicenet/layer1"
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/monitor/objects"
 	"github.com/alicenet/alicenet/utils"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -19,11 +18,11 @@ import (
 )
 
 // RetrieveGroupPublicKey retrieves participant's group public key (gpkj) from ETHDKG contract
-func RetrieveGroupPublicKey(callOpts *bind.CallOpts, eth layer1.Client, addr common.Address) ([4]*big.Int, error) {
+func RetrieveGroupPublicKey(callOpts *bind.CallOpts, eth layer1.Client, contracts layer1.AllSmartContracts, addr common.Address) ([4]*big.Int, error) {
 	var err error
 	var gpkjBig [4]*big.Int
 
-	ethdkg := ethereum.GetContracts().Ethdkg()
+	ethdkg := contracts.GetEthereumContracts().Ethdkg()
 
 	participantState, err := ethdkg.GetParticipantInternalState(callOpts, addr)
 	if err != nil {

--- a/layer1/executor/tasks/dkg/utils/utils.go
+++ b/layer1/executor/tasks/dkg/utils/utils.go
@@ -22,7 +22,7 @@ func RetrieveGroupPublicKey(callOpts *bind.CallOpts, eth layer1.Client, contract
 	var err error
 	var gpkjBig [4]*big.Int
 
-	ethdkg := contracts.GetEthereumContracts().Ethdkg()
+	ethdkg := contracts.EthereumContracts().Ethdkg()
 
 	participantState, err := ethdkg.GetParticipantInternalState(callOpts, addr)
 	if err != nil {

--- a/layer1/executor/tasks/interfaces.go
+++ b/layer1/executor/tasks/interfaces.go
@@ -13,7 +13,7 @@ import (
 
 // Task the interface requirements of a task
 type Task interface {
-	Initialize(ctx context.Context, cancelFunc context.CancelFunc, database *db.Database, logger *logrus.Entry, eth layer1.Client, name string, id string, taskResponseChan TaskResponseChan) error
+	Initialize(ctx context.Context, cancelFunc context.CancelFunc, database *db.Database, logger *logrus.Entry, eth layer1.Client, contracts layer1.AllSmartContracts, name string, id string, taskResponseChan TaskResponseChan) error
 	Prepare(ctx context.Context) *TaskErr
 	Execute(ctx context.Context) (*types.Transaction, *TaskErr)
 	ShouldExecute(ctx context.Context) (bool, *TaskErr)
@@ -28,6 +28,7 @@ type Task interface {
 	GetSubscribeOptions() *transaction.SubscribeOptions
 	GetCtx() context.Context
 	GetClient() layer1.Client
+	GetContractsHandler() layer1.AllSmartContracts
 	GetLogger() *logrus.Entry
 }
 

--- a/layer1/executor/tasks/snapshots/snapshot.go
+++ b/layer1/executor/tasks/snapshots/snapshot.go
@@ -84,7 +84,7 @@ func (t *SnapshotTask) Execute(ctx context.Context) (*types.Transaction, *tasks.
 		return nil, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingTxnOpts, err), true)
 	}
 	logger.Info("trying to commit snapshot")
-	txn, err := t.GetContractsHandler().GetEthereumContracts().Snapshots().Snapshot(txnOpts, snapshotState.RawSigGroup, snapshotState.RawBClaims)
+	txn, err := t.GetContractsHandler().EthereumContracts().Snapshots().Snapshot(txnOpts, snapshotState.RawSigGroup, snapshotState.RawBClaims)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("failed to send snapshot: %v", err), true)
 	}
@@ -108,7 +108,7 @@ func (t *SnapshotTask) ShouldExecute(ctx context.Context) (bool, *tasks.TaskErr)
 		return false, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingCallOpts, err), true)
 	}
 
-	height, err := t.GetContractsHandler().GetEthereumContracts().Snapshots().GetAliceNetHeightFromLatestSnapshot(opts)
+	height, err := t.GetContractsHandler().EthereumContracts().Snapshots().GetAliceNetHeightFromLatestSnapshot(opts)
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("failed to determine height: %v", err), true)
 	}

--- a/layer1/executor/tasks/snapshots/snapshot.go
+++ b/layer1/executor/tasks/snapshots/snapshot.go
@@ -6,7 +6,6 @@ import (
 	dangerousRand "math/rand"
 	"time"
 
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/snapshots/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -85,7 +84,7 @@ func (t *SnapshotTask) Execute(ctx context.Context) (*types.Transaction, *tasks.
 		return nil, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingTxnOpts, err), true)
 	}
 	logger.Info("trying to commit snapshot")
-	txn, err := ethereum.GetContracts().Snapshots().Snapshot(txnOpts, snapshotState.RawSigGroup, snapshotState.RawBClaims)
+	txn, err := t.GetContractsHandler().GetEthereumContracts().Snapshots().Snapshot(txnOpts, snapshotState.RawSigGroup, snapshotState.RawBClaims)
 	if err != nil {
 		return nil, tasks.NewTaskErr(fmt.Sprintf("failed to send snapshot: %v", err), true)
 	}
@@ -109,7 +108,7 @@ func (t *SnapshotTask) ShouldExecute(ctx context.Context) (bool, *tasks.TaskErr)
 		return false, tasks.NewTaskErr(fmt.Sprintf(tasks.FailedGettingCallOpts, err), true)
 	}
 
-	height, err := ethereum.GetContracts().Snapshots().GetAliceNetHeightFromLatestSnapshot(opts)
+	height, err := t.GetContractsHandler().GetEthereumContracts().Snapshots().GetAliceNetHeightFromLatestSnapshot(opts)
 	if err != nil {
 		return false, tasks.NewTaskErr(fmt.Sprintf("failed to determine height: %v", err), true)
 	}

--- a/layer1/handlers/contracts.go
+++ b/layer1/handlers/contracts.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"github.com/alicenet/alicenet/layer1"
+	"github.com/alicenet/alicenet/layer1/ethereum"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var _ layer1.AllSmartContracts = &AllSmartContractsHandle{}
+
+// AllSmartContractsHandle is bus where we can access all smart contracts from the
+// different layer1 clients.
+type AllSmartContractsHandle struct {
+	ethereumContracts *ethereum.Contracts
+}
+
+func NewAllSmartContractsHandle(eth *ethereum.Client, contractFactoryAddress common.Address) layer1.AllSmartContracts {
+	return &AllSmartContractsHandle{ethereumContracts: ethereum.NewContracts(eth, contractFactoryAddress)}
+}
+
+func (ch *AllSmartContractsHandle) GetEthereumContracts() layer1.EthereumContracts {
+	return ch.ethereumContracts
+}

--- a/layer1/handlers/contracts.go
+++ b/layer1/handlers/contracts.go
@@ -18,6 +18,6 @@ func NewAllSmartContractsHandle(eth *ethereum.Client, contractFactoryAddress com
 	return &AllSmartContractsHandle{ethereumContracts: ethereum.NewContracts(eth, contractFactoryAddress)}
 }
 
-func (ch *AllSmartContractsHandle) GetEthereumContracts() layer1.EthereumContracts {
+func (ch *AllSmartContractsHandle) EthereumContracts() layer1.EthereumContracts {
 	return ch.ethereumContracts
 }

--- a/layer1/layer1.go
+++ b/layer1/layer1.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/alicenet/alicenet/bridge/bindings"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -45,6 +46,32 @@ type Client interface {
 	RetryTransaction(ctx context.Context, tx *types.Transaction, baseFee *big.Int, gasTipCap *big.Int) (*types.Transaction, error)
 }
 
-type Contracts interface {
+type BasicContracts interface {
 	GetAllAddresses() []common.Address
+}
+
+type EthereumContracts interface {
+	BasicContracts
+	Ethdkg() bindings.IETHDKG
+	EthdkgAddress() common.Address
+	AToken() bindings.IAToken
+	ATokenAddress() common.Address
+	BToken() bindings.IBToken
+	BTokenAddress() common.Address
+	PublicStaking() bindings.IPublicStaking
+	PublicStakingAddress() common.Address
+	ValidatorStaking() bindings.IValidatorStaking
+	ValidatorStakingAddress() common.Address
+	ContractFactory() bindings.IAliceNetFactory
+	ContractFactoryAddress() common.Address
+	SnapshotsAddress() common.Address
+	Snapshots() bindings.ISnapshots
+	ValidatorPool() bindings.IValidatorPool
+	ValidatorPoolAddress() common.Address
+	Governance() bindings.IGovernance
+	GovernanceAddress() common.Address
+}
+
+type AllSmartContracts interface {
+	GetEthereumContracts() EthereumContracts
 }

--- a/layer1/layer1.go
+++ b/layer1/layer1.go
@@ -73,5 +73,5 @@ type EthereumContracts interface {
 }
 
 type AllSmartContracts interface {
-	GetEthereumContracts() EthereumContracts
+	EthereumContracts() EthereumContracts
 }

--- a/layer1/monitor/events/deposits.go
+++ b/layer1/monitor/events/deposits.go
@@ -18,7 +18,7 @@ func ProcessDepositReceived(eth layer1.Client, contracts layer1.AllSmartContract
 
 	logger.Info("ProcessDepositReceived() ...")
 
-	event, err := contracts.GetEthereumContracts().BToken().ParseDepositReceived(log)
+	event, err := contracts.EthereumContracts().BToken().ParseDepositReceived(log)
 	if err != nil {
 		return err
 	}

--- a/layer1/monitor/events/deposits.go
+++ b/layer1/monitor/events/deposits.go
@@ -8,18 +8,17 @@ import (
 	"github.com/alicenet/alicenet/constants"
 	"github.com/alicenet/alicenet/errorz"
 	"github.com/alicenet/alicenet/layer1"
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/monitor/interfaces"
 	"github.com/dgraph-io/badger/v2"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/sirupsen/logrus"
 )
 
-func ProcessDepositReceived(eth layer1.Client, logger *logrus.Entry, log types.Log, cdb *db.Database, monDB *db.Database, depositHandler interfaces.DepositHandler) error {
+func ProcessDepositReceived(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, cdb *db.Database, monDB *db.Database, depositHandler interfaces.DepositHandler) error {
 
 	logger.Info("ProcessDepositReceived() ...")
 
-	event, err := ethereum.GetContracts().BToken().ParseDepositReceived(log)
+	event, err := contracts.GetEthereumContracts().BToken().ParseDepositReceived(log)
 	if err != nil {
 		return err
 	}

--- a/layer1/monitor/events/dynamics.go
+++ b/layer1/monitor/events/dynamics.go
@@ -14,7 +14,7 @@ func ProcessValueUpdated(eth layer1.Client, contracts layer1.AllSmartContracts, 
 
 	logger.Info("ProcessValueUpdated() ...")
 
-	event, err := contracts.GetEthereumContracts().Governance().ParseValueUpdated(log)
+	event, err := contracts.EthereumContracts().Governance().ParseValueUpdated(log)
 	if err != nil {
 		return err
 	}

--- a/layer1/monitor/events/dynamics.go
+++ b/layer1/monitor/events/dynamics.go
@@ -5,17 +5,16 @@ import (
 
 	"github.com/alicenet/alicenet/consensus/db"
 	"github.com/alicenet/alicenet/layer1"
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/sirupsen/logrus"
 )
 
 // ProcessValueUpdated handles a dynamic value updating coming from our smart contract
-func ProcessValueUpdated(eth layer1.Client, logger *logrus.Entry, log types.Log, monDB *db.Database) error {
+func ProcessValueUpdated(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, monDB *db.Database) error {
 
 	logger.Info("ProcessValueUpdated() ...")
 
-	event, err := ethereum.GetContracts().Governance().ParseValueUpdated(log)
+	event, err := contracts.GetEthereumContracts().Governance().ParseValueUpdated(log)
 	if err != nil {
 		return err
 	}

--- a/layer1/monitor/events/ethdkg.go
+++ b/layer1/monitor/events/ethdkg.go
@@ -24,7 +24,7 @@ func isValidator(acct accounts.Account, state *objects.MonitorState) bool {
 func ProcessRegistrationOpened(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, monState *objects.MonitorState, monDB *db.Database, taskRequestChan chan<- tasks.TaskRequest) error {
 	logEntry := logger.WithField("eventProcessor", "ProcessRegistrationOpened")
 	logEntry.Info("processing registration")
-	event, err := contracts.GetEthereumContracts().Ethdkg().ParseRegistrationOpened(log)
+	event, err := contracts.EthereumContracts().Ethdkg().ParseRegistrationOpened(log)
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func ProcessAddressRegistered(eth layer1.Client, contracts layer1.AllSmartContra
 	logEntry := logger.WithField("eventProcessor", "ProcessAddressRegistered")
 	logEntry.Info("processing address registered")
 
-	event, err := contracts.GetEthereumContracts().Ethdkg().ParseAddressRegistered(log)
+	event, err := contracts.EthereumContracts().Ethdkg().ParseAddressRegistered(log)
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func ProcessRegistrationComplete(eth layer1.Client, contracts layer1.AllSmartCon
 		return nil
 	}
 
-	event, err := contracts.GetEthereumContracts().Ethdkg().ParseRegistrationComplete(log)
+	event, err := contracts.EthereumContracts().Ethdkg().ParseRegistrationComplete(log)
 	if err != nil {
 		return err
 	}
@@ -222,7 +222,7 @@ func ProcessShareDistribution(eth layer1.Client, contracts layer1.AllSmartContra
 	logEntry := logger.WithField("eventProcessor", "ProcessShareDistribution")
 	logEntry.Info("processing share distribution")
 
-	event, err := contracts.GetEthereumContracts().Ethdkg().ParseSharesDistributed(log)
+	event, err := contracts.EthereumContracts().Ethdkg().ParseSharesDistributed(log)
 	if err != nil {
 		return err
 	}
@@ -269,7 +269,7 @@ func ProcessShareDistributionComplete(eth layer1.Client, contracts layer1.AllSma
 		return nil
 	}
 
-	event, err := contracts.GetEthereumContracts().Ethdkg().ParseShareDistributionComplete(log)
+	event, err := contracts.EthereumContracts().Ethdkg().ParseShareDistributionComplete(log)
 	if err != nil {
 		return err
 	}
@@ -339,7 +339,7 @@ func ProcessKeyShareSubmitted(eth layer1.Client, contracts layer1.AllSmartContra
 	logEntry := logger.WithField("eventProcessor", "ProcessKeyShareSubmitted")
 	logEntry.Info("processing key share submission")
 
-	event, err := contracts.GetEthereumContracts().Ethdkg().ParseKeyShareSubmitted(log)
+	event, err := contracts.EthereumContracts().Ethdkg().ParseKeyShareSubmitted(log)
 	if err != nil {
 		return err
 	}
@@ -369,7 +369,7 @@ func ProcessKeyShareSubmissionComplete(eth layer1.Client, contracts layer1.AllSm
 	logEntry := logger.WithField("eventProcessor", "ProcessKeyShareSubmissionComplete")
 	logEntry.Info("processing key share submission complete")
 
-	event, err := contracts.GetEthereumContracts().Ethdkg().ParseKeyShareSubmissionComplete(log)
+	event, err := contracts.EthereumContracts().Ethdkg().ParseKeyShareSubmissionComplete(log)
 	if err != nil {
 		return err
 	}
@@ -426,7 +426,7 @@ func ProcessMPKSet(eth layer1.Client, contracts layer1.AllSmartContracts, logger
 	logEntry := logger.WithField("eventProcessor", "ProcessMPKSet")
 	logEntry.Info("processing master public key set")
 
-	event, err := contracts.GetEthereumContracts().Ethdkg().ParseMPKSet(log)
+	event, err := contracts.EthereumContracts().Ethdkg().ParseMPKSet(log)
 	if err != nil {
 		return err
 	}
@@ -507,7 +507,7 @@ func UpdateStateOnMPKSet(dkgState *state.DkgState, gpkjSubmissionStartBlock uint
 func ProcessGPKJSubmissionComplete(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, monDB *db.Database, taskRequestChan chan<- tasks.TaskRequest) error {
 	logEntry := logger.WithField("eventProcessor", "ProcessGPKJSubmissionComplete")
 	logEntry.Info("processing gpkj submission complete")
-	event, err := contracts.GetEthereumContracts().Ethdkg().ParseGPKJSubmissionComplete(log)
+	event, err := contracts.EthereumContracts().Ethdkg().ParseGPKJSubmissionComplete(log)
 	if err != nil {
 		return err
 	}

--- a/layer1/monitor/events/ethdkg.go
+++ b/layer1/monitor/events/ethdkg.go
@@ -3,7 +3,6 @@ package events
 import (
 	"github.com/alicenet/alicenet/consensus/db"
 	"github.com/alicenet/alicenet/layer1"
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg"
 	dkgtasks "github.com/alicenet/alicenet/layer1/executor/tasks/dkg"
@@ -22,10 +21,10 @@ func isValidator(acct accounts.Account, state *objects.MonitorState) bool {
 	return present
 }
 
-func ProcessRegistrationOpened(eth layer1.Client, logger *logrus.Entry, log types.Log, monState *objects.MonitorState, monDB *db.Database, taskRequestChan chan<- tasks.TaskRequest) error {
+func ProcessRegistrationOpened(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, monState *objects.MonitorState, monDB *db.Database, taskRequestChan chan<- tasks.TaskRequest) error {
 	logEntry := logger.WithField("eventProcessor", "ProcessRegistrationOpened")
 	logEntry.Info("processing registration")
-	event, err := ethereum.GetContracts().Ethdkg().ParseRegistrationOpened(log)
+	event, err := contracts.GetEthereumContracts().Ethdkg().ParseRegistrationOpened(log)
 	if err != nil {
 		return err
 	}
@@ -104,11 +103,11 @@ func UpdateStateOnRegistrationOpened(account accounts.Account, startBlock, phase
 	return dkgState, registrationTask, disputeMissingRegistrationTask
 }
 
-func ProcessAddressRegistered(eth layer1.Client, logger *logrus.Entry, log types.Log, monDB *db.Database) error {
+func ProcessAddressRegistered(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, monDB *db.Database) error {
 	logEntry := logger.WithField("eventProcessor", "ProcessAddressRegistered")
 	logEntry.Info("processing address registered")
 
-	event, err := ethereum.GetContracts().Ethdkg().ParseAddressRegistered(log)
+	event, err := contracts.GetEthereumContracts().Ethdkg().ParseAddressRegistered(log)
 	if err != nil {
 		return err
 	}
@@ -138,7 +137,7 @@ func ProcessAddressRegistered(eth layer1.Client, logger *logrus.Entry, log types
 	return nil
 }
 
-func ProcessRegistrationComplete(eth layer1.Client, logger *logrus.Entry, log types.Log, monDB *db.Database, taskRequestChan chan<- tasks.TaskRequest) error {
+func ProcessRegistrationComplete(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, monDB *db.Database, taskRequestChan chan<- tasks.TaskRequest) error {
 	logEntry := logger.WithField("eventProcessor", "ProcessRegistrationComplete")
 	logEntry.Info("processing registration complete")
 
@@ -155,7 +154,7 @@ func ProcessRegistrationComplete(eth layer1.Client, logger *logrus.Entry, log ty
 		return nil
 	}
 
-	event, err := ethereum.GetContracts().Ethdkg().ParseRegistrationComplete(log)
+	event, err := contracts.GetEthereumContracts().Ethdkg().ParseRegistrationComplete(log)
 	if err != nil {
 		return err
 	}
@@ -219,11 +218,11 @@ func UpdateStateOnRegistrationComplete(dkgState *state.DkgState, shareDistributi
 	return shareDistributionTask, disputeMissingShareDistributionTask, disputeBadSharesTasks
 }
 
-func ProcessShareDistribution(eth layer1.Client, logger *logrus.Entry, log types.Log, monDB *db.Database) error {
+func ProcessShareDistribution(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, monDB *db.Database) error {
 	logEntry := logger.WithField("eventProcessor", "ProcessShareDistribution")
 	logEntry.Info("processing share distribution")
 
-	event, err := ethereum.GetContracts().Ethdkg().ParseSharesDistributed(log)
+	event, err := contracts.GetEthereumContracts().Ethdkg().ParseSharesDistributed(log)
 	if err != nil {
 		return err
 	}
@@ -253,7 +252,7 @@ func ProcessShareDistribution(eth layer1.Client, logger *logrus.Entry, log types
 	return nil
 }
 
-func ProcessShareDistributionComplete(eth layer1.Client, logger *logrus.Entry, log types.Log, monDB *db.Database, taskRequestChan chan<- tasks.TaskRequest) error {
+func ProcessShareDistributionComplete(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, monDB *db.Database, taskRequestChan chan<- tasks.TaskRequest) error {
 	logEntry := logger.WithField("eventProcessor", "ProcessShareDistributionComplete")
 	logEntry.Info("processing share distribution complete")
 
@@ -270,7 +269,7 @@ func ProcessShareDistributionComplete(eth layer1.Client, logger *logrus.Entry, l
 		return nil
 	}
 
-	event, err := ethereum.GetContracts().Ethdkg().ParseShareDistributionComplete(log)
+	event, err := contracts.GetEthereumContracts().Ethdkg().ParseShareDistributionComplete(log)
 	if err != nil {
 		return err
 	}
@@ -336,11 +335,11 @@ func UpdateStateOnShareDistributionComplete(dkgState *state.DkgState, disputeSha
 	return disputeShareDistributionTasks, keyshareSubmissionTask, disputeMissingKeySharesTask
 }
 
-func ProcessKeyShareSubmitted(eth layer1.Client, logger *logrus.Entry, log types.Log, monDB *db.Database) error {
+func ProcessKeyShareSubmitted(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, monDB *db.Database) error {
 	logEntry := logger.WithField("eventProcessor", "ProcessKeyShareSubmitted")
 	logEntry.Info("processing key share submission")
 
-	event, err := ethereum.GetContracts().Ethdkg().ParseKeyShareSubmitted(log)
+	event, err := contracts.GetEthereumContracts().Ethdkg().ParseKeyShareSubmitted(log)
 	if err != nil {
 		return err
 	}
@@ -366,11 +365,11 @@ func ProcessKeyShareSubmitted(eth layer1.Client, logger *logrus.Entry, log types
 	return nil
 }
 
-func ProcessKeyShareSubmissionComplete(eth layer1.Client, logger *logrus.Entry, log types.Log, monDB *db.Database, taskRequestChan chan<- tasks.TaskRequest) error {
+func ProcessKeyShareSubmissionComplete(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, monDB *db.Database, taskRequestChan chan<- tasks.TaskRequest) error {
 	logEntry := logger.WithField("eventProcessor", "ProcessKeyShareSubmissionComplete")
 	logEntry.Info("processing key share submission complete")
 
-	event, err := ethereum.GetContracts().Ethdkg().ParseKeyShareSubmissionComplete(log)
+	event, err := contracts.GetEthereumContracts().Ethdkg().ParseKeyShareSubmissionComplete(log)
 	if err != nil {
 		return err
 	}
@@ -423,11 +422,11 @@ func UpdateStateOnKeyShareSubmissionComplete(dkgState *state.DkgState, mpkSubmis
 	return mpkSubmissionTask
 }
 
-func ProcessMPKSet(eth layer1.Client, logger *logrus.Entry, log types.Log, adminHandler monitorInterfaces.AdminHandler, monDB *db.Database, taskRequestChan chan<- tasks.TaskRequest) error {
+func ProcessMPKSet(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, adminHandler monitorInterfaces.AdminHandler, monDB *db.Database, taskRequestChan chan<- tasks.TaskRequest) error {
 	logEntry := logger.WithField("eventProcessor", "ProcessMPKSet")
 	logEntry.Info("processing master public key set")
 
-	event, err := ethereum.GetContracts().Ethdkg().ParseMPKSet(log)
+	event, err := contracts.GetEthereumContracts().Ethdkg().ParseMPKSet(log)
 	if err != nil {
 		return err
 	}
@@ -505,10 +504,10 @@ func UpdateStateOnMPKSet(dkgState *state.DkgState, gpkjSubmissionStartBlock uint
 	return gpkjSubmissionTask, disputeMissingGPKjTask, disputeGPKjTasks
 }
 
-func ProcessGPKJSubmissionComplete(eth layer1.Client, logger *logrus.Entry, log types.Log, monDB *db.Database, taskRequestChan chan<- tasks.TaskRequest) error {
+func ProcessGPKJSubmissionComplete(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, monDB *db.Database, taskRequestChan chan<- tasks.TaskRequest) error {
 	logEntry := logger.WithField("eventProcessor", "ProcessGPKJSubmissionComplete")
 	logEntry.Info("processing gpkj submission complete")
-	event, err := ethereum.GetContracts().Ethdkg().ParseGPKJSubmissionComplete(log)
+	event, err := contracts.GetEthereumContracts().Ethdkg().ParseGPKJSubmissionComplete(log)
 	if err != nil {
 		return err
 	}

--- a/layer1/monitor/events/setup.go
+++ b/layer1/monitor/events/setup.go
@@ -73,38 +73,38 @@ func RegisterETHDKGEvents(em *objects.EventMap, monDB *db.Database, adminHandler
 	ethDkgEvents := GetETHDKGEvents()
 
 	eventProcessorMap := make(map[string]objects.EventProcessor)
-	eventProcessorMap["RegistrationOpened"] = func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-		return ProcessRegistrationOpened(eth, logger, log, state, monDB, taskRequestChan)
+	eventProcessorMap["RegistrationOpened"] = func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+		return ProcessRegistrationOpened(eth, contracts, logger, log, state, monDB, taskRequestChan)
 	}
-	eventProcessorMap["AddressRegistered"] = func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-		return ProcessAddressRegistered(eth, logger, log, monDB)
+	eventProcessorMap["AddressRegistered"] = func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+		return ProcessAddressRegistered(eth, contracts, logger, log, monDB)
 	}
-	eventProcessorMap["RegistrationComplete"] = func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-		return ProcessRegistrationComplete(eth, logger, log, monDB, taskRequestChan)
+	eventProcessorMap["RegistrationComplete"] = func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+		return ProcessRegistrationComplete(eth, contracts, logger, log, monDB, taskRequestChan)
 	}
-	eventProcessorMap["SharesDistributed"] = func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-		return ProcessShareDistribution(eth, logger, log, monDB)
+	eventProcessorMap["SharesDistributed"] = func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+		return ProcessShareDistribution(eth, contracts, logger, log, monDB)
 	}
-	eventProcessorMap["ShareDistributionComplete"] = func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-		return ProcessShareDistributionComplete(eth, logger, log, monDB, taskRequestChan)
+	eventProcessorMap["ShareDistributionComplete"] = func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+		return ProcessShareDistributionComplete(eth, contracts, logger, log, monDB, taskRequestChan)
 	}
-	eventProcessorMap["KeyShareSubmitted"] = func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-		return ProcessKeyShareSubmitted(eth, logger, log, monDB)
+	eventProcessorMap["KeyShareSubmitted"] = func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+		return ProcessKeyShareSubmitted(eth, contracts, logger, log, monDB)
 	}
-	eventProcessorMap["KeyShareSubmissionComplete"] = func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-		return ProcessKeyShareSubmissionComplete(eth, logger, log, monDB, taskRequestChan)
+	eventProcessorMap["KeyShareSubmissionComplete"] = func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+		return ProcessKeyShareSubmissionComplete(eth, contracts, logger, log, monDB, taskRequestChan)
 	}
-	eventProcessorMap["MPKSet"] = func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-		return ProcessMPKSet(eth, logger, log, adminHandler, monDB, taskRequestChan)
+	eventProcessorMap["MPKSet"] = func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+		return ProcessMPKSet(eth, contracts, logger, log, adminHandler, monDB, taskRequestChan)
 	}
-	eventProcessorMap["ValidatorMemberAdded"] = func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-		return ProcessValidatorMemberAdded(eth, logger, state, log, monDB)
+	eventProcessorMap["ValidatorMemberAdded"] = func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+		return ProcessValidatorMemberAdded(eth, contracts, logger, state, log, monDB)
 	}
-	eventProcessorMap["GPKJSubmissionComplete"] = func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-		return ProcessGPKJSubmissionComplete(eth, logger, log, monDB, taskRequestChan)
+	eventProcessorMap["GPKJSubmissionComplete"] = func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+		return ProcessGPKJSubmissionComplete(eth, contracts, logger, log, monDB, taskRequestChan)
 	}
-	eventProcessorMap["ValidatorSetCompleted"] = func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-		return ProcessValidatorSetCompleted(eth, logger, state, log, monDB, adminHandler)
+	eventProcessorMap["ValidatorSetCompleted"] = func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+		return ProcessValidatorSetCompleted(eth, contracts, logger, state, log, monDB, adminHandler)
 	}
 
 	// actually register the events
@@ -133,8 +133,8 @@ func SetupEventMap(em *objects.EventMap, cdb *db.Database, monDB *db.Database, a
 	}
 
 	if err := em.Register(depositReceived.ID.String(), depositReceived.Name,
-		func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-			return ProcessDepositReceived(eth, logger, log, cdb, monDB, depositHandler)
+		func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+			return ProcessDepositReceived(eth, contracts, logger, log, cdb, monDB, depositHandler)
 		}); err != nil {
 		return err
 	}
@@ -147,8 +147,8 @@ func SetupEventMap(em *objects.EventMap, cdb *db.Database, monDB *db.Database, a
 	}
 
 	if err := em.Register(snapshotTakenEvent.ID.String(), snapshotTakenEvent.Name,
-		func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-			return ProcessSnapshotTaken(eth, logger, log, adminHandler, taskRequestChan)
+		func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+			return ProcessSnapshotTaken(eth, contracts, logger, log, adminHandler, taskRequestChan)
 		}); err != nil {
 		return err
 	}
@@ -161,8 +161,8 @@ func SetupEventMap(em *objects.EventMap, cdb *db.Database, monDB *db.Database, a
 	}
 
 	if err := em.Register(valueUpdatedEvent.ID.String(), valueUpdatedEvent.Name,
-		func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-			return ProcessValueUpdated(eth, logger, log, monDB)
+		func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+			return ProcessValueUpdated(eth, contracts, logger, log, monDB)
 		}); err != nil {
 		return err
 	}
@@ -176,8 +176,8 @@ func SetupEventMap(em *objects.EventMap, cdb *db.Database, monDB *db.Database, a
 		panic("could not find event ValidatorPool.ValidatorJoined")
 	}
 
-	processValidatorJoinedFunc := func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-		return ProcessValidatorJoined(eth, logger, state, log)
+	processValidatorJoinedFunc := func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+		return ProcessValidatorJoined(eth, contracts, logger, state, log)
 	}
 	if err := em.Register(validatorJoinedEvent.ID.String(), validatorJoinedEvent.Name, processValidatorJoinedFunc); err != nil {
 		panic(fmt.Sprintf("couldn't register validator joined event:%v", err))
@@ -189,8 +189,8 @@ func SetupEventMap(em *objects.EventMap, cdb *db.Database, monDB *db.Database, a
 		panic("could not find event ValidatorPool.ValidatorLeft")
 	}
 
-	processValidatorLeftFunc := func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-		return ProcessValidatorLeft(eth, logger, state, log)
+	processValidatorLeftFunc := func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+		return ProcessValidatorLeft(eth, contracts, logger, state, log)
 	}
 	if err := em.Register(validatorLeftEvent.ID.String(), validatorLeftEvent.Name, processValidatorLeftFunc); err != nil {
 		panic(fmt.Sprintf("couldn't register validator left event:%v", err))
@@ -201,8 +201,8 @@ func SetupEventMap(em *objects.EventMap, cdb *db.Database, monDB *db.Database, a
 		panic("could not find event ValidatorPool.ValidatorMinorSlashed")
 	}
 
-	processValidatorMinorSlashedFunc := func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-		return ProcessValidatorMinorSlashed(eth, logger, state, log)
+	processValidatorMinorSlashedFunc := func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+		return ProcessValidatorMinorSlashed(eth, contracts, logger, state, log)
 	}
 	if err := em.Register(validatorMinorSlashedEvent.ID.String(), validatorMinorSlashedEvent.Name, processValidatorMinorSlashedFunc); err != nil {
 		panic(fmt.Sprintf("couldn't register validator minor slashed event:%v", err))
@@ -214,8 +214,8 @@ func SetupEventMap(em *objects.EventMap, cdb *db.Database, monDB *db.Database, a
 		panic("could not find event ValidatorPool.ValidatorMajorSlashed")
 	}
 
-	processValidatorMajorSlashedFunc := func(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-		return ProcessValidatorMajorSlashed(eth, logger, state, log)
+	processValidatorMajorSlashedFunc := func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+		return ProcessValidatorMajorSlashed(eth, contracts, logger, state, log)
 	}
 	if err := em.Register(validatorMajorSlashedEvent.ID.String(), validatorMajorSlashedEvent.Name, processValidatorMajorSlashedFunc); err != nil {
 		panic(err)

--- a/layer1/monitor/events/snapshots.go
+++ b/layer1/monitor/events/snapshots.go
@@ -15,7 +15,7 @@ func ProcessSnapshotTaken(eth layer1.Client, contracts layer1.AllSmartContracts,
 
 	logger.Info("ProcessSnapshotTaken() ...")
 
-	c := contracts.GetEthereumContracts()
+	c := contracts.EthereumContracts()
 
 	event, err := c.Snapshots().ParseSnapshotTaken(log)
 	if err != nil {

--- a/layer1/monitor/events/snapshots.go
+++ b/layer1/monitor/events/snapshots.go
@@ -3,7 +3,6 @@ package events
 import (
 	"github.com/alicenet/alicenet/consensus/objs"
 	"github.com/alicenet/alicenet/layer1"
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/snapshots"
 	monInterfaces "github.com/alicenet/alicenet/layer1/monitor/interfaces"
@@ -12,11 +11,11 @@ import (
 )
 
 // ProcessSnapshotTaken handles receiving snapshots
-func ProcessSnapshotTaken(eth layer1.Client, logger *logrus.Entry, log types.Log, adminHandler monInterfaces.AdminHandler, taskRequestChan chan<- tasks.TaskRequest) error {
+func ProcessSnapshotTaken(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, adminHandler monInterfaces.AdminHandler, taskRequestChan chan<- tasks.TaskRequest) error {
 
 	logger.Info("ProcessSnapshotTaken() ...")
 
-	c := ethereum.GetContracts()
+	c := contracts.GetEthereumContracts()
 
 	event, err := c.Snapshots().ParseSnapshotTaken(log)
 	if err != nil {

--- a/layer1/monitor/events/validators.go
+++ b/layer1/monitor/events/validators.go
@@ -11,7 +11,6 @@ import (
 	"github.com/alicenet/alicenet/consensus/objs"
 	"github.com/alicenet/alicenet/crypto/bn256"
 	"github.com/alicenet/alicenet/layer1"
-	"github.com/alicenet/alicenet/layer1/ethereum"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/state"
 	"github.com/alicenet/alicenet/layer1/executor/tasks/dkg/utils"
 	monInterfaces "github.com/alicenet/alicenet/layer1/monitor/interfaces"
@@ -22,10 +21,10 @@ import (
 )
 
 // ProcessValidatorSetCompleted handles receiving validatorSet changes
-func ProcessValidatorSetCompleted(eth layer1.Client, logger *logrus.Entry, monitorState *objects.MonitorState, log types.Log, monDB *db.Database,
+func ProcessValidatorSetCompleted(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, monitorState *objects.MonitorState, log types.Log, monDB *db.Database,
 	adminHandler monInterfaces.AdminHandler) error {
 
-	c := ethereum.GetContracts()
+	c := contracts.GetEthereumContracts()
 
 	monitorState.Lock()
 	defer monitorState.Unlock()
@@ -90,12 +89,12 @@ func ProcessValidatorSetCompleted(eth layer1.Client, logger *logrus.Entry, monit
 }
 
 // ProcessValidatorMemberAdded handles receiving keys for a specific validator
-func ProcessValidatorMemberAdded(eth layer1.Client, logger *logrus.Entry, monitorState *objects.MonitorState, log types.Log, monDB *db.Database) error {
+func ProcessValidatorMemberAdded(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, monitorState *objects.MonitorState, log types.Log, monDB *db.Database) error {
 
 	monitorState.Lock()
 	defer monitorState.Unlock()
 
-	c := ethereum.GetContracts()
+	c := contracts.GetEthereumContracts()
 
 	event, err := c.Ethdkg().ParseValidatorMemberAdded(log)
 	if err != nil {
@@ -165,8 +164,8 @@ func ProcessValidatorMemberAdded(eth layer1.Client, logger *logrus.Entry, monito
 }
 
 // ProcessValidatorJoined handles the Minor Slash event
-func ProcessValidatorJoined(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-	event, err := ethereum.GetContracts().ValidatorPool().ParseValidatorJoined(log)
+func ProcessValidatorJoined(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+	event, err := contracts.GetEthereumContracts().ValidatorPool().ParseValidatorJoined(log)
 	if err != nil {
 		return err
 	}
@@ -183,8 +182,8 @@ func ProcessValidatorJoined(eth layer1.Client, logger *logrus.Entry, state *obje
 }
 
 // ProcessValidatorLeft handles the Minor Slash event
-func ProcessValidatorLeft(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-	event, err := ethereum.GetContracts().ValidatorPool().ParseValidatorLeft(log)
+func ProcessValidatorLeft(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+	event, err := contracts.GetEthereumContracts().ValidatorPool().ParseValidatorLeft(log)
 	if err != nil {
 		return err
 	}
@@ -203,8 +202,8 @@ func ProcessValidatorLeft(eth layer1.Client, logger *logrus.Entry, state *object
 }
 
 // ProcessValidatorMajorSlashed handles the Major Slash event
-func ProcessValidatorMajorSlashed(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-	event, err := ethereum.GetContracts().ValidatorPool().ParseValidatorMajorSlashed(log)
+func ProcessValidatorMajorSlashed(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+	event, err := contracts.GetEthereumContracts().ValidatorPool().ParseValidatorMajorSlashed(log)
 	if err != nil {
 		return err
 	}
@@ -222,9 +221,9 @@ func ProcessValidatorMajorSlashed(eth layer1.Client, logger *logrus.Entry, state
 }
 
 // ProcessValidatorMinorSlashed handles the Minor Slash event
-func ProcessValidatorMinorSlashed(eth layer1.Client, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+func ProcessValidatorMinorSlashed(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
 
-	event, err := ethereum.GetContracts().ValidatorPool().ParseValidatorMinorSlashed(log)
+	event, err := contracts.GetEthereumContracts().ValidatorPool().ParseValidatorMinorSlashed(log)
 	if err != nil {
 		return err
 	}

--- a/layer1/monitor/events/validators.go
+++ b/layer1/monitor/events/validators.go
@@ -24,7 +24,7 @@ import (
 func ProcessValidatorSetCompleted(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, monitorState *objects.MonitorState, log types.Log, monDB *db.Database,
 	adminHandler monInterfaces.AdminHandler) error {
 
-	c := contracts.GetEthereumContracts()
+	c := contracts.EthereumContracts()
 
 	monitorState.Lock()
 	defer monitorState.Unlock()
@@ -94,7 +94,7 @@ func ProcessValidatorMemberAdded(eth layer1.Client, contracts layer1.AllSmartCon
 	monitorState.Lock()
 	defer monitorState.Unlock()
 
-	c := contracts.GetEthereumContracts()
+	c := contracts.EthereumContracts()
 
 	event, err := c.Ethdkg().ParseValidatorMemberAdded(log)
 	if err != nil {
@@ -165,7 +165,7 @@ func ProcessValidatorMemberAdded(eth layer1.Client, contracts layer1.AllSmartCon
 
 // ProcessValidatorJoined handles the Minor Slash event
 func ProcessValidatorJoined(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-	event, err := contracts.GetEthereumContracts().ValidatorPool().ParseValidatorJoined(log)
+	event, err := contracts.EthereumContracts().ValidatorPool().ParseValidatorJoined(log)
 	if err != nil {
 		return err
 	}
@@ -183,7 +183,7 @@ func ProcessValidatorJoined(eth layer1.Client, contracts layer1.AllSmartContract
 
 // ProcessValidatorLeft handles the Minor Slash event
 func ProcessValidatorLeft(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-	event, err := contracts.GetEthereumContracts().ValidatorPool().ParseValidatorLeft(log)
+	event, err := contracts.EthereumContracts().ValidatorPool().ParseValidatorLeft(log)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func ProcessValidatorLeft(eth layer1.Client, contracts layer1.AllSmartContracts,
 
 // ProcessValidatorMajorSlashed handles the Major Slash event
 func ProcessValidatorMajorSlashed(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
-	event, err := contracts.GetEthereumContracts().ValidatorPool().ParseValidatorMajorSlashed(log)
+	event, err := contracts.EthereumContracts().ValidatorPool().ParseValidatorMajorSlashed(log)
 	if err != nil {
 		return err
 	}
@@ -223,7 +223,7 @@ func ProcessValidatorMajorSlashed(eth layer1.Client, contracts layer1.AllSmartCo
 // ProcessValidatorMinorSlashed handles the Minor Slash event
 func ProcessValidatorMinorSlashed(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
 
-	event, err := contracts.GetEthereumContracts().ValidatorPool().ParseValidatorMinorSlashed(log)
+	event, err := contracts.EthereumContracts().ValidatorPool().ParseValidatorMinorSlashed(log)
 	if err != nil {
 		return err
 	}

--- a/layer1/monitor/monitor_test.go
+++ b/layer1/monitor/monitor_test.go
@@ -70,7 +70,7 @@ func getMonitor(t *testing.T) (*monitor, *executor.TasksScheduler, chan tasks.Ta
 	txWatcher := transaction.NewWatcher(eth, 12, monDB, false, constants.TxPollingTime)
 	tasksScheduler, err := executor.NewTasksScheduler(monDB, eth, contracts, adminHandler, tasksReqChan, txWatcher)
 
-	mon, err := NewMonitor(monDB, monDB, adminHandler, depositHandler, eth, contracts, contracts.GetEthereumContracts().GetAllAddresses(), 2*time.Second, 100, tasksReqChan)
+	mon, err := NewMonitor(monDB, monDB, adminHandler, depositHandler, eth, contracts, contracts.EthereumContracts().GetAllAddresses(), 2*time.Second, 100, tasksReqChan)
 	assert.Nil(t, err)
 	EPOCH := uint32(1)
 	populateMonitor(mon.State, EPOCH)
@@ -93,7 +93,7 @@ func TestMonitorPersist(t *testing.T) {
 
 	contracts := mocks.NewMockAllSmartContracts()
 
-	newMon, err := NewMonitor(mon.db, mon.db, mocks.NewMockAdminHandler(), mocks.NewMockDepositHandler(), eth, contracts, contracts.GetEthereumContracts().GetAllAddresses(), 10*time.Millisecond, 100, make(chan tasks.TaskRequest, 10))
+	newMon, err := NewMonitor(mon.db, mon.db, mocks.NewMockAdminHandler(), mocks.NewMockDepositHandler(), eth, contracts, contracts.EthereumContracts().GetAllAddresses(), 10*time.Millisecond, 100, make(chan tasks.TaskRequest, 10))
 	assert.Nil(t, err)
 
 	err = newMon.State.LoadState(mon.db)

--- a/layer1/monitor/monitor_test.go
+++ b/layer1/monitor/monitor_test.go
@@ -65,11 +65,12 @@ func getMonitor(t *testing.T) (*monitor, *executor.TasksScheduler, chan tasks.Ta
 	adminHandler := mocks.NewMockAdminHandler()
 	depositHandler := mocks.NewMockDepositHandler()
 	eth := mocks.NewMockClient()
+	contracts := mocks.NewMockAllSmartContracts()
 	tasksReqChan := make(chan tasks.TaskRequest, 10)
 	txWatcher := transaction.NewWatcher(eth, 12, monDB, false, constants.TxPollingTime)
-	tasksScheduler, err := executor.NewTasksScheduler(monDB, eth, adminHandler, tasksReqChan, txWatcher)
+	tasksScheduler, err := executor.NewTasksScheduler(monDB, eth, contracts, adminHandler, tasksReqChan, txWatcher)
 
-	mon, err := NewMonitor(monDB, monDB, adminHandler, depositHandler, eth, mocks.NewMockContracts(), 2*time.Second, 100, tasksReqChan)
+	mon, err := NewMonitor(monDB, monDB, adminHandler, depositHandler, eth, contracts, contracts.GetEthereumContracts().GetAllAddresses(), 2*time.Second, 100, tasksReqChan)
 	assert.Nil(t, err)
 	EPOCH := uint32(1)
 	populateMonitor(mon.State, EPOCH)
@@ -90,7 +91,9 @@ func TestMonitorPersist(t *testing.T) {
 	err = mon.State.PersistState(mon.db)
 	assert.Nil(t, err)
 
-	newMon, err := NewMonitor(mon.db, mon.db, mocks.NewMockAdminHandler(), mocks.NewMockDepositHandler(), eth, mocks.NewMockContracts(), 10*time.Millisecond, 100, make(chan tasks.TaskRequest, 10))
+	contracts := mocks.NewMockAllSmartContracts()
+
+	newMon, err := NewMonitor(mon.db, mon.db, mocks.NewMockAdminHandler(), mocks.NewMockDepositHandler(), eth, contracts, contracts.GetEthereumContracts().GetAllAddresses(), 10*time.Millisecond, 100, make(chan tasks.TaskRequest, 10))
 	assert.Nil(t, err)
 
 	err = newMon.State.LoadState(mon.db)

--- a/layer1/monitor/objects/event_map.go
+++ b/layer1/monitor/objects/event_map.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type EventProcessor func(eth layer1.Client, logger *logrus.Entry, state *MonitorState, log types.Log) error
+type EventProcessor func(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, state *MonitorState, log types.Log) error
 
 type EventInformation struct {
 	Name      string

--- a/layer1/tests/setup.go
+++ b/layer1/tests/setup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alicenet/alicenet/consensus/db"
 	"github.com/alicenet/alicenet/layer1"
 	"github.com/alicenet/alicenet/layer1/ethereum"
+	"github.com/alicenet/alicenet/layer1/handlers"
 	"github.com/alicenet/alicenet/layer1/transaction"
 	"github.com/alicenet/alicenet/test/mocks"
 	"github.com/alicenet/alicenet/utils"
@@ -165,6 +166,7 @@ func FundAccounts(eth layer1.Client, watcher transaction.Watcher, logger *logrus
 
 type ClientFixture struct {
 	Client         layer1.Client
+	Contracts      layer1.AllSmartContracts
 	Watcher        transaction.Watcher
 	MonitorDb      *db.Database
 	FactoryAddress string
@@ -208,6 +210,7 @@ func NewClientFixture(hardhat *Hardhat, finalityDelay uint64, numAccounts int, l
 	}
 
 	factoryAddress := ""
+	var contracts layer1.AllSmartContracts
 	if deployContracts {
 		baseFilesDir := filepath.Join(GetProjectRootPath(), "scripts", "base-files")
 		factoryAddress, err = hardhat.DeployFactoryAndContracts(tempDir, baseFilesDir)
@@ -221,7 +224,7 @@ func NewClientFixture(hardhat *Hardhat, finalityDelay uint64, numAccounts int, l
 		for _, account := range eth.GetKnownAccounts() {
 			validatorsAddresses = append(validatorsAddresses, account.Address.Hex())
 		}
-		ethereum.NewContracts(eth, common.HexToAddress(factoryAddress))
+		contracts = handlers.NewAllSmartContractsHandle(eth, common.HexToAddress(factoryAddress))
 		if registerValidators {
 			hardhat.RegisterValidators(factoryAddress, validatorsAddresses)
 		}
@@ -229,6 +232,7 @@ func NewClientFixture(hardhat *Hardhat, finalityDelay uint64, numAccounts int, l
 
 	return &ClientFixture{
 		Client:         eth,
+		Contracts:      contracts,
 		Watcher:        watcher,
 		MonitorDb:      MonitorDb,
 		TempDir:        tempDir,

--- a/test/mocks/generate.go
+++ b/test/mocks/generate.go
@@ -5,7 +5,7 @@ package mocks
 //go:generate go-mockgen -f -i Task -o interfaces_executor.mockgen.go ../../layer1/executor/tasks
 //go:generate go-mockgen -f -i Watcher -i ReceiptResponse -o interfaces_transaction.mockgen.go ../../layer1/transaction
 //go:generate go-mockgen -f -i DepositHandler -i AdminHandler -i AdminClient -o interfaces_monitor.mockgen.go ../../layer1/monitor/interfaces
-//go:generate go-mockgen -f -i Client -i Contracts -o interfaces_ethereum.mockgen.go ../../layer1
+//go:generate go-mockgen -f -i Client -i AllSmartContracts -i EthereumContracts -o interfaces_ethereum.mockgen.go ../../layer1
 
 // Mocks created from bindings:
 

--- a/test/mocks/interfaces_ethereum.mockgen.go
+++ b/test/mocks/interfaces_ethereum.mockgen.go
@@ -19,9 +19,9 @@ import (
 // interface (from the package github.com/alicenet/alicenet/layer1) used for
 // unit testing.
 type MockAllSmartContracts struct {
-	// GetEthereumContractsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetEthereumContracts.
-	GetEthereumContractsFunc *AllSmartContractsGetEthereumContractsFunc
+	// EthereumContractsFunc is an instance of a mock function object
+	// controlling the behavior of the method EthereumContracts.
+	EthereumContractsFunc *AllSmartContractsEthereumContractsFunc
 }
 
 // NewMockAllSmartContracts creates a new mock of the AllSmartContracts
@@ -29,7 +29,7 @@ type MockAllSmartContracts struct {
 // overwritten.
 func NewMockAllSmartContracts() *MockAllSmartContracts {
 	return &MockAllSmartContracts{
-		GetEthereumContractsFunc: &AllSmartContractsGetEthereumContractsFunc{
+		EthereumContractsFunc: &AllSmartContractsEthereumContractsFunc{
 			defaultHook: func() (r0 layer1.EthereumContracts) {
 				return
 			},
@@ -42,9 +42,9 @@ func NewMockAllSmartContracts() *MockAllSmartContracts {
 // overwritten.
 func NewStrictMockAllSmartContracts() *MockAllSmartContracts {
 	return &MockAllSmartContracts{
-		GetEthereumContractsFunc: &AllSmartContractsGetEthereumContractsFunc{
+		EthereumContractsFunc: &AllSmartContractsEthereumContractsFunc{
 			defaultHook: func() layer1.EthereumContracts {
-				panic("unexpected invocation of MockAllSmartContracts.GetEthereumContracts")
+				panic("unexpected invocation of MockAllSmartContracts.EthereumContracts")
 			},
 		},
 	}
@@ -55,43 +55,43 @@ func NewStrictMockAllSmartContracts() *MockAllSmartContracts {
 // implementation, unless overwritten.
 func NewMockAllSmartContractsFrom(i layer1.AllSmartContracts) *MockAllSmartContracts {
 	return &MockAllSmartContracts{
-		GetEthereumContractsFunc: &AllSmartContractsGetEthereumContractsFunc{
-			defaultHook: i.GetEthereumContracts,
+		EthereumContractsFunc: &AllSmartContractsEthereumContractsFunc{
+			defaultHook: i.EthereumContracts,
 		},
 	}
 }
 
-// AllSmartContractsGetEthereumContractsFunc describes the behavior when the
-// GetEthereumContracts method of the parent MockAllSmartContracts instance
-// is invoked.
-type AllSmartContractsGetEthereumContractsFunc struct {
+// AllSmartContractsEthereumContractsFunc describes the behavior when the
+// EthereumContracts method of the parent MockAllSmartContracts instance is
+// invoked.
+type AllSmartContractsEthereumContractsFunc struct {
 	defaultHook func() layer1.EthereumContracts
 	hooks       []func() layer1.EthereumContracts
-	history     []AllSmartContractsGetEthereumContractsFuncCall
+	history     []AllSmartContractsEthereumContractsFuncCall
 	mutex       sync.Mutex
 }
 
-// GetEthereumContracts delegates to the next hook function in the queue and
+// EthereumContracts delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockAllSmartContracts) GetEthereumContracts() layer1.EthereumContracts {
-	r0 := m.GetEthereumContractsFunc.nextHook()()
-	m.GetEthereumContractsFunc.appendCall(AllSmartContractsGetEthereumContractsFuncCall{r0})
+func (m *MockAllSmartContracts) EthereumContracts() layer1.EthereumContracts {
+	r0 := m.EthereumContractsFunc.nextHook()()
+	m.EthereumContractsFunc.appendCall(AllSmartContractsEthereumContractsFuncCall{r0})
 	return r0
 }
 
-// SetDefaultHook sets function that is called when the GetEthereumContracts
+// SetDefaultHook sets function that is called when the EthereumContracts
 // method of the parent MockAllSmartContracts instance is invoked and the
 // hook queue is empty.
-func (f *AllSmartContractsGetEthereumContractsFunc) SetDefaultHook(hook func() layer1.EthereumContracts) {
+func (f *AllSmartContractsEthereumContractsFunc) SetDefaultHook(hook func() layer1.EthereumContracts) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetEthereumContracts method of the parent MockAllSmartContracts instance
+// EthereumContracts method of the parent MockAllSmartContracts instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *AllSmartContractsGetEthereumContractsFunc) PushHook(hook func() layer1.EthereumContracts) {
+func (f *AllSmartContractsEthereumContractsFunc) PushHook(hook func() layer1.EthereumContracts) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -99,20 +99,20 @@ func (f *AllSmartContractsGetEthereumContractsFunc) PushHook(hook func() layer1.
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *AllSmartContractsGetEthereumContractsFunc) SetDefaultReturn(r0 layer1.EthereumContracts) {
+func (f *AllSmartContractsEthereumContractsFunc) SetDefaultReturn(r0 layer1.EthereumContracts) {
 	f.SetDefaultHook(func() layer1.EthereumContracts {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *AllSmartContractsGetEthereumContractsFunc) PushReturn(r0 layer1.EthereumContracts) {
+func (f *AllSmartContractsEthereumContractsFunc) PushReturn(r0 layer1.EthereumContracts) {
 	f.PushHook(func() layer1.EthereumContracts {
 		return r0
 	})
 }
 
-func (f *AllSmartContractsGetEthereumContractsFunc) nextHook() func() layer1.EthereumContracts {
+func (f *AllSmartContractsEthereumContractsFunc) nextHook() func() layer1.EthereumContracts {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -125,28 +125,27 @@ func (f *AllSmartContractsGetEthereumContractsFunc) nextHook() func() layer1.Eth
 	return hook
 }
 
-func (f *AllSmartContractsGetEthereumContractsFunc) appendCall(r0 AllSmartContractsGetEthereumContractsFuncCall) {
+func (f *AllSmartContractsEthereumContractsFunc) appendCall(r0 AllSmartContractsEthereumContractsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of
-// AllSmartContractsGetEthereumContractsFuncCall objects describing the
-// invocations of this function.
-func (f *AllSmartContractsGetEthereumContractsFunc) History() []AllSmartContractsGetEthereumContractsFuncCall {
+// History returns a sequence of AllSmartContractsEthereumContractsFuncCall
+// objects describing the invocations of this function.
+func (f *AllSmartContractsEthereumContractsFunc) History() []AllSmartContractsEthereumContractsFuncCall {
 	f.mutex.Lock()
-	history := make([]AllSmartContractsGetEthereumContractsFuncCall, len(f.history))
+	history := make([]AllSmartContractsEthereumContractsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// AllSmartContractsGetEthereumContractsFuncCall is an object that describes
-// an invocation of method GetEthereumContracts on an instance of
+// AllSmartContractsEthereumContractsFuncCall is an object that describes an
+// invocation of method EthereumContracts on an instance of
 // MockAllSmartContracts.
-type AllSmartContractsGetEthereumContractsFuncCall struct {
+type AllSmartContractsEthereumContractsFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 layer1.EthereumContracts
@@ -154,13 +153,13 @@ type AllSmartContractsGetEthereumContractsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c AllSmartContractsGetEthereumContractsFuncCall) Args() []interface{} {
+func (c AllSmartContractsEthereumContractsFuncCall) Args() []interface{} {
 	return []interface{}{}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c AllSmartContractsGetEthereumContractsFuncCall) Results() []interface{} {
+func (c AllSmartContractsEthereumContractsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/test/mocks/interfaces_executor.mockgen.go
+++ b/test/mocks/interfaces_executor.mockgen.go
@@ -33,6 +33,9 @@ type MockTask struct {
 	// GetClientFunc is an instance of a mock function object controlling
 	// the behavior of the method GetClient.
 	GetClientFunc *TaskGetClientFunc
+	// GetContractsHandlerFunc is an instance of a mock function object
+	// controlling the behavior of the method GetContractsHandler.
+	GetContractsHandlerFunc *TaskGetContractsHandlerFunc
 	// GetCtxFunc is an instance of a mock function object controlling the
 	// behavior of the method GetCtx.
 	GetCtxFunc *TaskGetCtxFunc
@@ -97,6 +100,11 @@ func NewMockTask() *MockTask {
 				return
 			},
 		},
+		GetContractsHandlerFunc: &TaskGetContractsHandlerFunc{
+			defaultHook: func() (r0 layer1.AllSmartContracts) {
+				return
+			},
+		},
 		GetCtxFunc: &TaskGetCtxFunc{
 			defaultHook: func() (r0 context.Context) {
 				return
@@ -133,7 +141,7 @@ func NewMockTask() *MockTask {
 			},
 		},
 		InitializeFunc: &TaskInitializeFunc{
-			defaultHook: func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, string, string, tasks.TaskResponseChan) (r0 error) {
+			defaultHook: func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, layer1.AllSmartContracts, string, string, tasks.TaskResponseChan) (r0 error) {
 				return
 			},
 		},
@@ -184,6 +192,11 @@ func NewStrictMockTask() *MockTask {
 				panic("unexpected invocation of MockTask.GetClient")
 			},
 		},
+		GetContractsHandlerFunc: &TaskGetContractsHandlerFunc{
+			defaultHook: func() layer1.AllSmartContracts {
+				panic("unexpected invocation of MockTask.GetContractsHandler")
+			},
+		},
 		GetCtxFunc: &TaskGetCtxFunc{
 			defaultHook: func() context.Context {
 				panic("unexpected invocation of MockTask.GetCtx")
@@ -220,7 +233,7 @@ func NewStrictMockTask() *MockTask {
 			},
 		},
 		InitializeFunc: &TaskInitializeFunc{
-			defaultHook: func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, string, string, tasks.TaskResponseChan) error {
+			defaultHook: func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, layer1.AllSmartContracts, string, string, tasks.TaskResponseChan) error {
 				panic("unexpected invocation of MockTask.Initialize")
 			},
 		},
@@ -260,6 +273,9 @@ func NewMockTaskFrom(i tasks.Task) *MockTask {
 		},
 		GetClientFunc: &TaskGetClientFunc{
 			defaultHook: i.GetClient,
+		},
+		GetContractsHandlerFunc: &TaskGetContractsHandlerFunc{
+			defaultHook: i.GetContractsHandler,
 		},
 		GetCtxFunc: &TaskGetCtxFunc{
 			defaultHook: i.GetCtx,
@@ -787,6 +803,105 @@ func (c TaskGetClientFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c TaskGetClientFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// TaskGetContractsHandlerFunc describes the behavior when the
+// GetContractsHandler method of the parent MockTask instance is invoked.
+type TaskGetContractsHandlerFunc struct {
+	defaultHook func() layer1.AllSmartContracts
+	hooks       []func() layer1.AllSmartContracts
+	history     []TaskGetContractsHandlerFuncCall
+	mutex       sync.Mutex
+}
+
+// GetContractsHandler delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockTask) GetContractsHandler() layer1.AllSmartContracts {
+	r0 := m.GetContractsHandlerFunc.nextHook()()
+	m.GetContractsHandlerFunc.appendCall(TaskGetContractsHandlerFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the GetContractsHandler
+// method of the parent MockTask instance is invoked and the hook queue is
+// empty.
+func (f *TaskGetContractsHandlerFunc) SetDefaultHook(hook func() layer1.AllSmartContracts) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetContractsHandler method of the parent MockTask instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *TaskGetContractsHandlerFunc) PushHook(hook func() layer1.AllSmartContracts) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *TaskGetContractsHandlerFunc) SetDefaultReturn(r0 layer1.AllSmartContracts) {
+	f.SetDefaultHook(func() layer1.AllSmartContracts {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *TaskGetContractsHandlerFunc) PushReturn(r0 layer1.AllSmartContracts) {
+	f.PushHook(func() layer1.AllSmartContracts {
+		return r0
+	})
+}
+
+func (f *TaskGetContractsHandlerFunc) nextHook() func() layer1.AllSmartContracts {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *TaskGetContractsHandlerFunc) appendCall(r0 TaskGetContractsHandlerFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of TaskGetContractsHandlerFuncCall objects
+// describing the invocations of this function.
+func (f *TaskGetContractsHandlerFunc) History() []TaskGetContractsHandlerFuncCall {
+	f.mutex.Lock()
+	history := make([]TaskGetContractsHandlerFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// TaskGetContractsHandlerFuncCall is an object that describes an invocation
+// of method GetContractsHandler on an instance of MockTask.
+type TaskGetContractsHandlerFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 layer1.AllSmartContracts
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c TaskGetContractsHandlerFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c TaskGetContractsHandlerFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -1480,23 +1595,23 @@ func (c TaskGetSubscribeOptionsFuncCall) Results() []interface{} {
 // TaskInitializeFunc describes the behavior when the Initialize method of
 // the parent MockTask instance is invoked.
 type TaskInitializeFunc struct {
-	defaultHook func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, string, string, tasks.TaskResponseChan) error
-	hooks       []func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, string, string, tasks.TaskResponseChan) error
+	defaultHook func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, layer1.AllSmartContracts, string, string, tasks.TaskResponseChan) error
+	hooks       []func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, layer1.AllSmartContracts, string, string, tasks.TaskResponseChan) error
 	history     []TaskInitializeFuncCall
 	mutex       sync.Mutex
 }
 
 // Initialize delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockTask) Initialize(v0 context.Context, v1 context.CancelFunc, v2 *db.Database, v3 *logrus.Entry, v4 layer1.Client, v5 string, v6 string, v7 tasks.TaskResponseChan) error {
-	r0 := m.InitializeFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6, v7)
-	m.InitializeFunc.appendCall(TaskInitializeFuncCall{v0, v1, v2, v3, v4, v5, v6, v7, r0})
+func (m *MockTask) Initialize(v0 context.Context, v1 context.CancelFunc, v2 *db.Database, v3 *logrus.Entry, v4 layer1.Client, v5 layer1.AllSmartContracts, v6 string, v7 string, v8 tasks.TaskResponseChan) error {
+	r0 := m.InitializeFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6, v7, v8)
+	m.InitializeFunc.appendCall(TaskInitializeFuncCall{v0, v1, v2, v3, v4, v5, v6, v7, v8, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the Initialize method of
 // the parent MockTask instance is invoked and the hook queue is empty.
-func (f *TaskInitializeFunc) SetDefaultHook(hook func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, string, string, tasks.TaskResponseChan) error) {
+func (f *TaskInitializeFunc) SetDefaultHook(hook func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, layer1.AllSmartContracts, string, string, tasks.TaskResponseChan) error) {
 	f.defaultHook = hook
 }
 
@@ -1504,7 +1619,7 @@ func (f *TaskInitializeFunc) SetDefaultHook(hook func(context.Context, context.C
 // Initialize method of the parent MockTask instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *TaskInitializeFunc) PushHook(hook func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, string, string, tasks.TaskResponseChan) error) {
+func (f *TaskInitializeFunc) PushHook(hook func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, layer1.AllSmartContracts, string, string, tasks.TaskResponseChan) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1513,19 +1628,19 @@ func (f *TaskInitializeFunc) PushHook(hook func(context.Context, context.CancelF
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *TaskInitializeFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, string, string, tasks.TaskResponseChan) error {
+	f.SetDefaultHook(func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, layer1.AllSmartContracts, string, string, tasks.TaskResponseChan) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *TaskInitializeFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, string, string, tasks.TaskResponseChan) error {
+	f.PushHook(func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, layer1.AllSmartContracts, string, string, tasks.TaskResponseChan) error {
 		return r0
 	})
 }
 
-func (f *TaskInitializeFunc) nextHook() func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, string, string, tasks.TaskResponseChan) error {
+func (f *TaskInitializeFunc) nextHook() func(context.Context, context.CancelFunc, *db.Database, *logrus.Entry, layer1.Client, layer1.AllSmartContracts, string, string, tasks.TaskResponseChan) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1575,13 +1690,16 @@ type TaskInitializeFuncCall struct {
 	Arg4 layer1.Client
 	// Arg5 is the value of the 6th argument passed to this method
 	// invocation.
-	Arg5 string
+	Arg5 layer1.AllSmartContracts
 	// Arg6 is the value of the 7th argument passed to this method
 	// invocation.
 	Arg6 string
 	// Arg7 is the value of the 8th argument passed to this method
 	// invocation.
-	Arg7 tasks.TaskResponseChan
+	Arg7 string
+	// Arg8 is the value of the 9th argument passed to this method
+	// invocation.
+	Arg8 tasks.TaskResponseChan
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -1590,7 +1708,7 @@ type TaskInitializeFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c TaskInitializeFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6, c.Arg7}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6, c.Arg7, c.Arg8}
 }
 
 // Results returns an interface slice containing the results of this


### PR DESCRIPTION
## Scope

Implementing the singleton pattern for the setup of the Ethereum smart contracts was not a good call since it makes the unit tests way harder to setup. This PR is replacing the singleton pattern with a handlers pattern. This new pattern should make the implementation of multiple layer1 blockchains a little bit easier in the future.

TODO:
Once we start adding new layer1 patterns, we probably will need a handler for layer1 clients and move the events and tasks to their own layer sub-packages.  
