### PR TITLE
Add tool to remove hardhat console logs from contracts

### DIFF
--- a/bridge/contracts/AToken.sol
+++ b/bridge/contracts/AToken.sol
@@ -5,7 +5,6 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "./utils/Admin.sol";
 import "./utils/ImmutableAuth.sol";
-import "hardhat/console.sol";
 import "contracts/interfaces/IAToken.sol";
 
 /// @custom:salt AToken

--- a/bridge/contracts/StateMigration.sol
+++ b/bridge/contracts/StateMigration.sol
@@ -12,8 +12,6 @@ import "contracts/utils/ImmutableAuth.sol";
 import "contracts/libraries/parsers/BClaimsParserLibrary.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
-import "hardhat/console.sol";
-
 contract ExternalStore is ImmutableFactory {
     uint256[4] internal _tokenIDs;
     uint256 internal _counter;

--- a/bridge/hardhat.config.ts
+++ b/bridge/hardhat.config.ts
@@ -13,6 +13,7 @@ import "./scripts/generateImmutableAuth";
 import "./scripts/lib/alicenetFactoryTasks";
 import "./scripts/lib/alicenetTasks";
 import "./scripts/lib/gogogen";
+import "hardhat-log-remover";
 require("dotenv").config();
 
 /**

--- a/bridge/package-lock.json
+++ b/bridge/package-lock.json
@@ -48,6 +48,7 @@
         "hardhat-contract-sizer": "^2.6.1",
         "hardhat-deploy": "^0.11.11",
         "hardhat-gas-reporter": "^1.0.8",
+        "hardhat-log-remover": "^2.0.2",
         "mocha": "^10.0.0",
         "prettier": "^2.7.1",
         "prettier-plugin-organize-imports": "^3.0.0",
@@ -19473,6 +19474,15 @@
       },
       "peerDependencies": {
         "hardhat": "^2.0.2"
+      }
+    },
+    "node_modules/hardhat-log-remover": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hardhat-log-remover/-/hardhat-log-remover-2.0.2.tgz",
+      "integrity": "sha512-TvEWOisQmZUZ7Mlb7s4XYS/MxgZzjFJSjDI8v3uTcrD6aaXy1QtomW6D6WNsISEWtwwRlSntOGpHQwFjrz2MCw==",
+      "dev": true,
+      "peerDependencies": {
+        "hardhat": "^2.0.0"
       }
     },
     "node_modules/hardhat/node_modules/@types/bn.js": {
@@ -43189,6 +43199,13 @@
         "eth-gas-reporter": "^0.2.24",
         "sha1": "^1.1.1"
       }
+    },
+    "hardhat-log-remover": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hardhat-log-remover/-/hardhat-log-remover-2.0.2.tgz",
+      "integrity": "sha512-TvEWOisQmZUZ7Mlb7s4XYS/MxgZzjFJSjDI8v3uTcrD6aaXy1QtomW6D6WNsISEWtwwRlSntOGpHQwFjrz2MCw==",
+      "dev": true,
+      "requires": {}
     },
     "has": {
       "version": "1.0.3",

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -15,7 +15,8 @@
     "clean": "rm -rf typechain-types && hardhat clean && rm -rf bindings artifacts",
     "compile": "hardhat compile",
     "generate": "hardhat go-go-gen --out bindings --pkg bindings --in bindings/bindings-artifacts && ./bindings/generate.sh && ts-node scripts/build/build.ts",
-    "build": "npm run clean && npm run compile && npm run generate",
+    "build": "npm run clean && npm run compile && npm run remove-logs && npm run generate",
+    "remove-logs": "hardhat remove-logs",
     "postinstall": "sh ../scripts/base-scripts/init-githooks.sh || true"
   },
   "devDependencies": {
@@ -54,6 +55,7 @@
     "hardhat-contract-sizer": "^2.6.1",
     "hardhat-deploy": "^0.11.11",
     "hardhat-gas-reporter": "^1.0.8",
+    "hardhat-log-remover": "^2.0.2",
     "mocha": "^10.0.0",
     "prettier": "^2.7.1",
     "prettier-plugin-organize-imports": "^3.0.0",

--- a/bridge/test/contract-mocks/publicStaking/ReentrantMocks.sol
+++ b/bridge/test/contract-mocks/publicStaking/ReentrantMocks.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.11;
 
 import "test/contract-mocks/publicStaking/BaseMock.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
-import "hardhat/console.sol";
 
 contract ReentrantLoopEthCollectorAccount is BaseMock {
     uint256 internal _tokenID;

--- a/bridge/test/contract-mocks/registration/RegisterValidators.sol
+++ b/bridge/test/contract-mocks/registration/RegisterValidators.sol
@@ -12,8 +12,6 @@ import "contracts/utils/ImmutableAuth.sol";
 import "contracts/libraries/parsers/BClaimsParserLibrary.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
-import "hardhat/console.sol";
-
 contract ExternalStoreRegistration is ImmutableFactory {
     uint256 internal _counter;
     uint256[] internal _tokenIDs;


### PR DESCRIPTION
## Scope

Added a hardhat plugin to automatically remove any console.log imports and usage in our smart contracts. The dev will need to run `npm run build` in other to make sure that the tool is executed. 
