### PR TITLE
Adding in integration code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,4 +165,8 @@ jobs:
         run: |
           set -euo pipefail
           ./scripts/main.sh init 5
-          go test -tags=integration -race -json -timeout=30m ${{ matrix.test-cmd }} 2>&1 | tee /tmp/gotest.log | gotestfmt
+          go test -tags=integration -race -json -covermode=atomic -coverpkg ./... -coverprofile=coverage.out -timeout=30m ${{ matrix.test-cmd }} 2>&1 | tee /tmp/gotest.log | gotestfmt
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.out
+          verbose: true


### PR DESCRIPTION
## Scope

- Code coverage generated from integration tests.

## Why?

- Get a true reflection of code coverage.