### PR TITLE
Adding in npm ci step for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
           cache: "npm"
           cache-dependency-path: bridge/package-lock.json
       - run: npm --prefix bridge/ ci
+      - run: npm --prefix bridge/ run compile
       - uses: ./.github/actions/alicenet-config
       - name: Set up gotestfmt
         run: go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,12 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: "bridge/.nvmrc"
+          cache: "npm"
+          cache-dependency-path: bridge/package-lock.json
+      - run: npm --prefix bridge/ ci
       - uses: ./.github/actions/alicenet-config
       - name: Set up gotestfmt
         run: go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest


### PR DESCRIPTION
## Scope

- node is set up and packages installed before running

## Why?

- Integration tests have a dependency on hardhat, controlled via npm
