### PR TITLE
move deposit info to debug for monitor

### DIFF
--- a/layer1/monitor/events/deposits.go
+++ b/layer1/monitor/events/deposits.go
@@ -16,8 +16,6 @@ import (
 
 func ProcessDepositReceived(eth layer1.Client, contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, cdb *db.Database, monDB *db.Database, depositHandler interfaces.DepositHandler) error {
 
-	logger.Info("ProcessDepositReceived() ...")
-
 	event, err := contracts.EthereumContracts().BToken().ParseDepositReceived(log)
 	if err != nil {
 		return err
@@ -30,7 +28,7 @@ func ProcessDepositReceived(eth layer1.Client, contracts layer1.AllSmartContract
 		"DepositID": event.DepositID,
 		"Depositor": event.Depositor,
 		"Amount":    event.Amount,
-	}).Info("Deposit received")
+	}).Debugf("Deposit received")
 
 	err = cdb.Update(func(txn *badger.Txn) error {
 		depositNonce := event.DepositID.Bytes()

--- a/layer1/monitor/events/deposits.go
+++ b/layer1/monitor/events/deposits.go
@@ -28,7 +28,7 @@ func ProcessDepositReceived(eth layer1.Client, contracts layer1.AllSmartContract
 		"DepositID": event.DepositID,
 		"Depositor": event.Depositor,
 		"Amount":    event.Amount,
-	}).Debugf("Deposit received")
+	}).Debug("Deposit received")
 
 	err = cdb.Update(func(txn *badger.Txn) error {
 		depositNonce := event.DepositID.Bytes()


### PR DESCRIPTION
## Scope

What is changing with this PR?
Moving deposit logging info to debug

## Why?
Deposits (should) happen regularly from external sources, which floods the logs. 

Why are we doing this?
To not have log clutter from external sources

## Todos

If any, what are the follow-up tasks required other than merging this PR? Have they been arranged?

- evaluate if this is happening in other places in the monitor
