### PR TITLE
Loosen code coverage to 50%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,4 +7,4 @@ coverage:
   status:
     patch:
       default:
-        target: 75%
+        target: 50%


### PR DESCRIPTION
## Scope

Reducing project-wide coverage requirement from 75% to 50%.

## Why?

Just adding noise until we can get coverage up to a higher level.