### PR TITLE
Hacky fix to remove warning at boot

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -260,6 +260,10 @@ func main() {
 		for cmd := range options {
 			// Find all the flags
 			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+				// -help defined by pflag internals and will not parse correctly.
+				if flag.Name == "help" {
+					return
+				}
 				err := flag.Value.Set(viper.GetString(flag.Name))
 				if err != nil {
 					logger.Warnf("Setting flag %q failed:%q", flag.Name, err)


### PR DESCRIPTION
## Scope

Workaround for `-help` flag causing warnings in logs.

## Why?

Logs should be clean.

## Follow on

We should revisit the entirety of our configuration to leverage `viper` or some other mechanism that requires less manual work.