### PR TITLE
Fixed bug in consensus

### DIFF
--- a/consensus/lstate/engine_test.go
+++ b/consensus/lstate/engine_test.go
@@ -953,51 +953,120 @@ func TestEngine_updateLocalStateInternal11(t *testing.T) {
 	})
 }
 
-/*
-	TODO: FIX AND BRING THIS BACK
-*/
-// PVCurrent
+// NOT PVCurrent
 // PVTOExpired.
-// func TestEngine_updateLocalStateInternal12(t *testing.T) {
-// 	engine := initEngine(t, nil)
+func TestEngine_updateLocalStateInternal12(t *testing.T) {
+	engine := initEngine(t, nil)
 
-// 	os := createOwnState(t, 2)
-// 	rs := createRoundState(t, os)
-// 	vs := createValidatorsSet(t, os, rs)
-// 	rss := createRoundStates(os, rs, vs, &objs.OwnValidatingState{})
+	os := createOwnState(t, 2)
+	rs := createRoundState(t, os)
+	vs := createValidatorsSet(t, os, rs)
+	rss := createRoundStates(os, rs, vs, &objs.OwnValidatingState{})
 
-// 	_, bnSigners, bnShares, secpSigners, secpPubks := makeSigners(t)
-// 	if len(secpPubks) != len(bnShares) {
-// 		t.Fatal("key length mismatch")
-// 	}
+	rsBytes, err := rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)].MarshalBinary()
+	if err != nil {
+		t.Fatalf("Shouldn't have raised error: %v", err)
+	}
+	newRS := &objs.RoundState{}
+	err = newRS.UnmarshalBinary(rsBytes)
+	if err != nil {
+		t.Fatalf("Shouldn't have raised error: %v", err)
+	}
 
-// 	height := uint32(2)
-// 	round := uint32(3)
-// 	prevBlock := crypto.Hasher([]byte("0"))
-// 	_, _, pvl, _, _, _, _, _, _ := buildRound(t, bnSigners, bnShares, secpSigners, height, round, prevBlock)
+	rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)] = newRS
 
-// 	rsBytes, err := rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)].MarshalBinary()
-// 	if err != nil {
-// 		t.Fatalf("Shouldn't have raised error: %v", err)
-// 	}
-// 	newRS := &objs.RoundState{}
-// 	err = newRS.UnmarshalBinary(rsBytes)
-// 	if err != nil {
-// 		t.Fatalf("Shouldn't have raised error: %v", err)
-// 	}
-// 	newRS.PreVote = pvl[0]
-// 	//newRS.RCert.RClaims.Height = 1
-// 	//newRS.RCert.RClaims.Round = 1
-// 	rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)] = newRS
+	_ = engine.sstore.database.Update(func(txn *badger.Txn) error {
+		ok, err := engine.updateLocalStateInternal(txn, rss)
+		assert.Nil(t, err)
+		assert.True(t, ok)
 
-// 	_ = engine.sstore.database.Update(func(txn *badger.Txn) error {
-// 		ok, err := engine.updateLocalStateInternal(txn, rss)
-// 		assert.Nil(t, err)
-// 		assert.True(t, ok)
+		return nil
+	})
+}
 
-// 		return nil
-// 	})
-// }
+// NOT PVCurrent
+// PVTOExpired.
+func TestEngine_updateLocalStateInternal12_2(t *testing.T) {
+	engine := initEngine(t, nil)
+
+	os := createOwnState(t, 2)
+	rs := createRoundState(t, os)
+	vs := createValidatorsSet(t, os, rs)
+	rss := createRoundStates(os, rs, vs, &objs.OwnValidatingState{})
+
+	_, bnSigners, bnShares, secpSigners, secpPubks := makeSigners(t)
+	if len(secpPubks) != len(bnShares) {
+		t.Fatal("key length mismatch")
+	}
+
+	height := uint32(2)
+	round := uint32(3)
+	prevBlock := crypto.Hasher([]byte("0"))
+	_, _, pvl, _, _, _, _, _, _ := buildRound(t, bnSigners, bnShares, secpSigners, height, round, prevBlock)
+
+	rsBytes, err := rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)].MarshalBinary()
+	if err != nil {
+		t.Fatalf("Shouldn't have raised error: %v", err)
+	}
+	newRS := &objs.RoundState{}
+	err = newRS.UnmarshalBinary(rsBytes)
+	if err != nil {
+		t.Fatalf("Shouldn't have raised error: %v", err)
+	}
+	newRS.PreVote = pvl[0]
+	rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)] = newRS
+
+	_ = engine.sstore.database.Update(func(txn *badger.Txn) error {
+		ok, err := engine.updateLocalStateInternal(txn, rss)
+		assert.NotNil(t, err)
+		assert.False(t, ok)
+
+		return nil
+	})
+}
+
+// NOT PVCurrent
+// PVTOExpired.
+func TestEngine_updateLocalStateInternal12_3(t *testing.T) {
+	engine := initEngine(t, nil)
+
+	os := createOwnState(t, 2)
+	rs := createRoundState(t, os)
+	vs := createValidatorsSet(t, os, rs)
+	rss := createRoundStates(os, rs, vs, &objs.OwnValidatingState{})
+
+	_, bnSigners, bnShares, secpSigners, secpPubks := makeSigners(t)
+	if len(secpPubks) != len(bnShares) {
+		t.Fatal("key length mismatch")
+	}
+
+	height := uint32(2)
+	round := uint32(3)
+	prevBlock := crypto.Hasher([]byte("0"))
+	_, _, pvl, _, _, _, _, _, _ := buildRound(t, bnSigners, bnShares, secpSigners, height, round, prevBlock)
+
+	rsBytes, err := rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)].MarshalBinary()
+	if err != nil {
+		t.Fatalf("Shouldn't have raised error: %v", err)
+	}
+	newRS := &objs.RoundState{}
+	err = newRS.UnmarshalBinary(rsBytes)
+	if err != nil {
+		t.Fatalf("Shouldn't have raised error: %v", err)
+	}
+	newRS.PreVote = pvl[0]
+	newRS.RCert.RClaims.Height = 2
+	newRS.RCert.RClaims.Round = 3
+	rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)] = newRS
+
+	_ = engine.sstore.database.Update(func(txn *badger.Txn) error {
+		ok, err := engine.updateLocalStateInternal(txn, rss)
+		assert.NotNil(t, err)
+		assert.False(t, ok)
+
+		return nil
+	})
+}
 
 // PVCurrent
 // NOT PVTOExpired.
@@ -1042,51 +1111,89 @@ func TestEngine_updateLocalStateInternal13(t *testing.T) {
 	})
 }
 
-/*
-	TODO: FIX AND BRING THIS BACK
-*/
-// PVNCurrent
+// NOT PVNCurrent
 // PVTOExpired.
-// func TestEngine_updateLocalStateInternal14(t *testing.T) {
-// 	engine := initEngine(t, nil)
+func TestEngine_updateLocalStateInternal14(t *testing.T) {
+	engine := initEngine(t, nil)
 
-// 	os := createOwnState(t, 2)
-// 	rs := createRoundState(t, os)
-// 	vs := createValidatorsSet(t, os, rs)
-// 	rss := createRoundStates(os, rs, vs, &objs.OwnValidatingState{})
+	os := createOwnState(t, 2)
+	rs := createRoundState(t, os)
+	vs := createValidatorsSet(t, os, rs)
+	rss := createRoundStates(os, rs, vs, &objs.OwnValidatingState{})
 
-// 	_, bnSigners, bnShares, secpSigners, secpPubks := makeSigners(t)
-// 	if len(secpPubks) != len(bnShares) {
-// 		t.Fatal("key length mismatch")
-// 	}
+	_, bnSigners, bnShares, secpSigners, secpPubks := makeSigners(t)
+	if len(secpPubks) != len(bnShares) {
+		t.Fatal("key length mismatch")
+	}
 
-// 	height := uint32(2)
-// 	round := uint32(3)
-// 	prevBlock := crypto.Hasher([]byte("0"))
-// 	_, _, _, pvnl, _, _, _, _, _ := buildRound(t, bnSigners, bnShares, secpSigners, height, round, prevBlock)
+	height := uint32(2)
+	round := uint32(3)
+	prevBlock := crypto.Hasher([]byte("0"))
+	_, _, _, pvnl, _, _, _, _, _ := buildRound(t, bnSigners, bnShares, secpSigners, height, round, prevBlock)
 
-// 	rsBytes, err := rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)].MarshalBinary()
-// 	if err != nil {
-// 		t.Fatalf("Shouldn't have raised error: %v", err)
-// 	}
-// 	newRS := &objs.RoundState{}
-// 	err = newRS.UnmarshalBinary(rsBytes)
-// 	if err != nil {
-// 		t.Fatalf("Shouldn't have raised error: %v", err)
-// 	}
-// 	newRS.PreVoteNil = pvnl[0]
-// 	newRS.RCert.RClaims.Height = 2
-// 	newRS.RCert.RClaims.Round = 3
-// 	rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)] = newRS
+	rsBytes, err := rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)].MarshalBinary()
+	if err != nil {
+		t.Fatalf("Shouldn't have raised error: %v", err)
+	}
+	newRS := &objs.RoundState{}
+	err = newRS.UnmarshalBinary(rsBytes)
+	if err != nil {
+		t.Fatalf("Shouldn't have raised error: %v", err)
+	}
+	newRS.PreVoteNil = pvnl[0]
+	rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)] = newRS
 
-// 	_ = engine.sstore.database.Update(func(txn *badger.Txn) error {
-// 		ok, err := engine.updateLocalStateInternal(txn, rss)
-// 		assert.Nil(t, err)
-// 		assert.True(t, ok)
+	_ = engine.sstore.database.Update(func(txn *badger.Txn) error {
+		ok, err := engine.updateLocalStateInternal(txn, rss)
+		assert.NotNil(t, err)
+		assert.False(t, ok)
 
-// 		return nil
-// 	})
-// }
+		return nil
+	})
+}
+
+// NOT PVNCurrent
+// PVTOExpired.
+func TestEngine_updateLocalStateInternal14_2(t *testing.T) {
+	engine := initEngine(t, nil)
+
+	os := createOwnState(t, 2)
+	rs := createRoundState(t, os)
+	vs := createValidatorsSet(t, os, rs)
+	rss := createRoundStates(os, rs, vs, &objs.OwnValidatingState{})
+
+	_, bnSigners, bnShares, secpSigners, secpPubks := makeSigners(t)
+	if len(secpPubks) != len(bnShares) {
+		t.Fatal("key length mismatch")
+	}
+
+	height := uint32(2)
+	round := uint32(3)
+	prevBlock := crypto.Hasher([]byte("0"))
+	_, _, _, pvnl, _, _, _, _, _ := buildRound(t, bnSigners, bnShares, secpSigners, height, round, prevBlock)
+
+	rsBytes, err := rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)].MarshalBinary()
+	if err != nil {
+		t.Fatalf("Shouldn't have raised error: %v", err)
+	}
+	newRS := &objs.RoundState{}
+	err = newRS.UnmarshalBinary(rsBytes)
+	if err != nil {
+		t.Fatalf("Shouldn't have raised error: %v", err)
+	}
+	newRS.PreVoteNil = pvnl[0]
+	newRS.RCert.RClaims.Height = 2
+	newRS.RCert.RClaims.Round = 3
+	rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)] = newRS
+
+	_ = engine.sstore.database.Update(func(txn *badger.Txn) error {
+		ok, err := engine.updateLocalStateInternal(txn, rss)
+		assert.NotNil(t, err)
+		assert.False(t, ok)
+
+		return nil
+	})
+}
 
 // PVNCurrent
 // NOT PVTOExpired.

--- a/consensus/lstate/engine_test.go
+++ b/consensus/lstate/engine_test.go
@@ -953,48 +953,51 @@ func TestEngine_updateLocalStateInternal11(t *testing.T) {
 	})
 }
 
+/*
+	TODO: FIX AND BRING THIS BACK
+*/
 // PVCurrent
 // PVTOExpired.
-func TestEngine_updateLocalStateInternal12(t *testing.T) {
-	engine := initEngine(t, nil)
+// func TestEngine_updateLocalStateInternal12(t *testing.T) {
+// 	engine := initEngine(t, nil)
 
-	os := createOwnState(t, 2)
-	rs := createRoundState(t, os)
-	vs := createValidatorsSet(t, os, rs)
-	rss := createRoundStates(os, rs, vs, &objs.OwnValidatingState{})
+// 	os := createOwnState(t, 2)
+// 	rs := createRoundState(t, os)
+// 	vs := createValidatorsSet(t, os, rs)
+// 	rss := createRoundStates(os, rs, vs, &objs.OwnValidatingState{})
 
-	_, bnSigners, bnShares, secpSigners, secpPubks := makeSigners(t)
-	if len(secpPubks) != len(bnShares) {
-		t.Fatal("key length mismatch")
-	}
+// 	_, bnSigners, bnShares, secpSigners, secpPubks := makeSigners(t)
+// 	if len(secpPubks) != len(bnShares) {
+// 		t.Fatal("key length mismatch")
+// 	}
 
-	height := uint32(2)
-	round := uint32(3)
-	prevBlock := crypto.Hasher([]byte("0"))
-	_, _, pvl, _, _, _, _, _, _ := buildRound(t, bnSigners, bnShares, secpSigners, height, round, prevBlock)
+// 	height := uint32(2)
+// 	round := uint32(3)
+// 	prevBlock := crypto.Hasher([]byte("0"))
+// 	_, _, pvl, _, _, _, _, _, _ := buildRound(t, bnSigners, bnShares, secpSigners, height, round, prevBlock)
 
-	rsBytes, err := rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)].MarshalBinary()
-	if err != nil {
-		t.Fatalf("Shouldn't have raised error: %v", err)
-	}
-	newRS := &objs.RoundState{}
-	err = newRS.UnmarshalBinary(rsBytes)
-	if err != nil {
-		t.Fatalf("Shouldn't have raised error: %v", err)
-	}
-	newRS.PreVote = pvl[0]
-	newRS.RCert.RClaims.Height = 2
-	newRS.RCert.RClaims.Round = 3
-	rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)] = newRS
+// 	rsBytes, err := rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)].MarshalBinary()
+// 	if err != nil {
+// 		t.Fatalf("Shouldn't have raised error: %v", err)
+// 	}
+// 	newRS := &objs.RoundState{}
+// 	err = newRS.UnmarshalBinary(rsBytes)
+// 	if err != nil {
+// 		t.Fatalf("Shouldn't have raised error: %v", err)
+// 	}
+// 	newRS.PreVote = pvl[0]
+// 	//newRS.RCert.RClaims.Height = 1
+// 	//newRS.RCert.RClaims.Round = 1
+// 	rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)] = newRS
 
-	_ = engine.sstore.database.Update(func(txn *badger.Txn) error {
-		ok, err := engine.updateLocalStateInternal(txn, rss)
-		assert.Nil(t, err)
-		assert.True(t, ok)
+// 	_ = engine.sstore.database.Update(func(txn *badger.Txn) error {
+// 		ok, err := engine.updateLocalStateInternal(txn, rss)
+// 		assert.Nil(t, err)
+// 		assert.True(t, ok)
 
-		return nil
-	})
-}
+// 		return nil
+// 	})
+// }
 
 // PVCurrent
 // NOT PVTOExpired.
@@ -1039,48 +1042,51 @@ func TestEngine_updateLocalStateInternal13(t *testing.T) {
 	})
 }
 
+/*
+	TODO: FIX AND BRING THIS BACK
+*/
 // PVNCurrent
 // PVTOExpired.
-func TestEngine_updateLocalStateInternal14(t *testing.T) {
-	engine := initEngine(t, nil)
+// func TestEngine_updateLocalStateInternal14(t *testing.T) {
+// 	engine := initEngine(t, nil)
 
-	os := createOwnState(t, 2)
-	rs := createRoundState(t, os)
-	vs := createValidatorsSet(t, os, rs)
-	rss := createRoundStates(os, rs, vs, &objs.OwnValidatingState{})
+// 	os := createOwnState(t, 2)
+// 	rs := createRoundState(t, os)
+// 	vs := createValidatorsSet(t, os, rs)
+// 	rss := createRoundStates(os, rs, vs, &objs.OwnValidatingState{})
 
-	_, bnSigners, bnShares, secpSigners, secpPubks := makeSigners(t)
-	if len(secpPubks) != len(bnShares) {
-		t.Fatal("key length mismatch")
-	}
+// 	_, bnSigners, bnShares, secpSigners, secpPubks := makeSigners(t)
+// 	if len(secpPubks) != len(bnShares) {
+// 		t.Fatal("key length mismatch")
+// 	}
 
-	height := uint32(2)
-	round := uint32(3)
-	prevBlock := crypto.Hasher([]byte("0"))
-	_, _, _, pvnl, _, _, _, _, _ := buildRound(t, bnSigners, bnShares, secpSigners, height, round, prevBlock)
+// 	height := uint32(2)
+// 	round := uint32(3)
+// 	prevBlock := crypto.Hasher([]byte("0"))
+// 	_, _, _, pvnl, _, _, _, _, _ := buildRound(t, bnSigners, bnShares, secpSigners, height, round, prevBlock)
 
-	rsBytes, err := rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)].MarshalBinary()
-	if err != nil {
-		t.Fatalf("Shouldn't have raised error: %v", err)
-	}
-	newRS := &objs.RoundState{}
-	err = newRS.UnmarshalBinary(rsBytes)
-	if err != nil {
-		t.Fatalf("Shouldn't have raised error: %v", err)
-	}
-	newRS.PreVoteNil = pvnl[0]
-	newRS.RCert.RClaims.Height = 2
-	newRS.RCert.RClaims.Round = 3
-	rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)] = newRS
+// 	rsBytes, err := rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)].MarshalBinary()
+// 	if err != nil {
+// 		t.Fatalf("Shouldn't have raised error: %v", err)
+// 	}
+// 	newRS := &objs.RoundState{}
+// 	err = newRS.UnmarshalBinary(rsBytes)
+// 	if err != nil {
+// 		t.Fatalf("Shouldn't have raised error: %v", err)
+// 	}
+// 	newRS.PreVoteNil = pvnl[0]
+// 	newRS.RCert.RClaims.Height = 2
+// 	newRS.RCert.RClaims.Round = 3
+// 	rss.PeerStateMap[string(vs.Validators[len(vs.Validators)-1].VAddr)] = newRS
 
-	_ = engine.sstore.database.Update(func(txn *badger.Txn) error {
-		ok, err := engine.updateLocalStateInternal(txn, rss)
-		assert.Nil(t, err)
-		assert.True(t, ok)
+// 	_ = engine.sstore.database.Update(func(txn *badger.Txn) error {
+// 		ok, err := engine.updateLocalStateInternal(txn, rss)
+// 		assert.Nil(t, err)
+// 		assert.True(t, ok)
 
-		return nil
-	})
-}
+// 		return nil
+// 	})
+// }
 
 // PVNCurrent
 // NOT PVTOExpired.

--- a/consensus/lstate/statechnglocal.go
+++ b/consensus/lstate/statechnglocal.go
@@ -280,11 +280,9 @@ func (ce *Engine) doPendingPreCommit(txn *badger.Txn, rs *RoundStates) error {
 	// clear consensus if the total votes is
 	// greater than threshold
 	if rcert.RClaims.Round != constants.DEADBLOCKROUND {
-		if len(pvl)+len(pvnl) >= rs.GetCurrentThreshold() {
-			if err := ce.castPreCommitNil(txn, rs); err != nil {
-				utils.DebugTrace(ce.logger, err)
-				return err
-			}
+		if err := ce.castPreCommitNil(txn, rs); err != nil {
+			utils.DebugTrace(ce.logger, err)
+			return err
 		}
 	}
 	// threshold not met as of yet


### PR DESCRIPTION
## Scope

What is changing with this PR?
Fixed a bug in consensus that would block it after an accusation was found. Shout out to @nelsonhp for helping debugging, identifying and fixing this one.

## Why?

Why are we doing this?
Because otherwise consensus would halt forever after an accusation was found and the malicious validator was evicted.

## Round of tests

#### Unit tests
- [x] Consensus unit tests

#### Integration tests
- [x] Deployment
- [x] ETHDKG
- [x] Consensus working normally **without** any transactions on the network
- [x] Sync
- [x] Snapshots
- [x] Fast sync
- [x] Consensus working normally **with** transactions on the network
- [x] Sync while transactions are being processed by the network
- [x] Fast sync while transactions are being processed by the network
