### PR TITLE
cli fixes

### DIFF
--- a/cmd/validator/validator.go
+++ b/cmd/validator/validator.go
@@ -47,7 +47,7 @@ import (
 
 // Command is the cobra.Command specifically for running as a node.
 var Command = cobra.Command{
-	Use:   "validator",
+	Use:   "node",
 	Short: "Starts a node",
 	Long:  "Runs a AliceNet node in mining or non-mining mode",
 	Run:   validatorNode,

--- a/constants/shared.go
+++ b/constants/shared.go
@@ -117,6 +117,7 @@ var ValidLoggers []string = []string{
 	"services",
 	"settings",
 	"validator",
+	"node",
 	"muxhandler",
 	"bootnode",
 	"p2pmux",

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -162,19 +162,19 @@ CHECK_EXISTING() {
 RUN_VALIDATOR() {
     # Run a validator
     CHECK_EXISTING $1
-    ./alicenet --config ./scripts/generated/config/validator$1.toml validator
+    ./alicenet --config ./scripts/generated/config/validator$1.toml node
 }
 
 RUN_NODE() {
     # Run a normal node (non validator)
     CHECK_EXISTING $1
-    ./alicenet --config ./scripts/generated/extra-nodes/config/node$1.toml validator
+    ./alicenet --config ./scripts/generated/extra-nodes/config/node$1.toml node
 }
 
 RACE_VALIDATOR() {
     # Run a validator
     CHECK_EXISTING $1
-    ./alicerace --config ./scripts/generated/config/validator$1.toml validator
+    ./alicerace --config ./scripts/generated/config/validator$1.toml node
 }
 
 STATUS() {


### PR DESCRIPTION
## Scope
Addressing both tickets:
https://madhive.atlassian.net/browse/MP-842
https://madhive.atlassian.net/browse/MP-843

Now the user is able to start a node using only `./alicenet` command

## Why?
To improve user experience
