### PR TITLE
Updating buf dependencies

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,4 +4,4 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 7529bb85c9cd4c489dba05e04769c547
+    commit: 62f35d8aed1149c291d606d958a7ce32


### PR DESCRIPTION
## Scope

Updating but dependencies as old ones have been purged.

## Why?

Generate is broken until this is done.