### PR TITLE
Ignore releaser ci on dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,7 @@ jobs:
 
   goreleaser:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Scope

Don't run goreleaser CI on actions spawned by Dependabot.

## Why?

Exfiltration risk.