### PR TITLE
Add script to deploy ALCB locally

### DIFF
--- a/bridge/scripts/lib/alicenetTasks.ts
+++ b/bridge/scripts/lib/alicenetTasks.ts
@@ -11,8 +11,12 @@ import { task, types } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 // import { ValidatorPool } from "../../typechain-types";
 import axios from "axios";
-import { getGasPrices } from "./alicenetFactoryTasks";
-import { DEFAULT_CONFIG_OUTPUT_DIR } from "./constants";
+import { getEventVar, getGasPrices } from "./alicenetFactoryTasks";
+import {
+  CONTRACT_ADDR,
+  DEFAULT_CONFIG_OUTPUT_DIR,
+  DEPLOYED_RAW,
+} from "./constants";
 import { readDeploymentArgs } from "./deployment/deploymentConfigUtil";
 export type MultiCallArgsStruct = {
   target: string;
@@ -1358,6 +1362,29 @@ task("update-alicenet-node-version", "Set the Canonical AliceNet Node Version")
       throw new Error(`Receipt indicates failure: ${rept}`);
     }
     console.log("Done");
+  });
+
+task("deploy-alcb", "Task to deploy ALCB")
+  .addParam(
+    "factoryAddress",
+    "the default factory address from factoryState will be used if not set"
+  )
+  .setAction(async (taskArgs, hre) => {
+    const factory = await hre.ethers.getContractAt(
+      "AliceNetFactory",
+      taskArgs.factoryAddress
+    );
+    const ALCB_BASE = await hre.ethers.getContractFactory("BToken");
+    const deploymentCode = ALCB_BASE.getDeployTransaction(factory.address)
+      .data as BytesLike;
+    const tx = await factory.deployCreate(deploymentCode);
+    const receipt = await tx.wait();
+    const alcbAddress = getEventVar(receipt, DEPLOYED_RAW, CONTRACT_ADDR);
+    console.log("ALCB/BToken address: ", alcbAddress);
+    await factory.addNewExternalContract(
+      hre.ethers.utils.formatBytes32String("BToken"),
+      alcbAddress
+    );
   });
 
 async function mintATokenTo(

--- a/scripts/base-scripts/deploy.sh
+++ b/scripts/base-scripts/deploy.sh
@@ -15,7 +15,6 @@ npx hardhat set-local-environment-interval-mining --network $NETWORK --enable-au
 cp ../scripts/base-files/deploymentList ../scripts/generated/deploymentList
 cp ../scripts/base-files/deploymentArgsTemplate ../scripts/generated/deploymentArgsTemplate
 
-
 npx hardhat --network "$NETWORK" --show-stack-traces deploy-contracts --input-folder ../scripts/generated
 addr="$(grep -Pzo "\[$NETWORK\]\ndefaultFactoryAddress = \".*\"\n" ../scripts/generated/factoryState | grep -a "defaultFactoryAddress = .*" | awk '{print $NF}')"
 
@@ -26,13 +25,13 @@ if [[ -z "${FACTORY_ADDRESS}" ]]; then
 fi
 
 for filePath in $(ls ../scripts/generated/config | xargs); do
-    sed -e "s/factoryAddress = .*/factoryAddress = $FACTORY_ADDRESS/" "../scripts/generated/config/$filePath" > "../scripts/generated/config/$filePath".bk &&\
-    mv "../scripts/generated/config/$filePath".bk "../scripts/generated/config/$filePath"
+    sed -e "s/factoryAddress = .*/factoryAddress = $FACTORY_ADDRESS/" "../scripts/generated/config/$filePath" >"../scripts/generated/config/$filePath".bk &&
+        mv "../scripts/generated/config/$filePath".bk "../scripts/generated/config/$filePath"
 done
 
 cp ../scripts/base-files/owner.toml ../scripts/generated/owner.toml
-sed -e "s/factoryAddress = .*/factoryAddress = $FACTORY_ADDRESS/" "../scripts/generated/owner.toml" > "../scripts/generated/owner.toml".bk &&\
-mv "../scripts/generated/owner.toml".bk "../scripts/generated/owner.toml"
+sed -e "s/factoryAddress = .*/factoryAddress = $FACTORY_ADDRESS/" "../scripts/generated/owner.toml" >"../scripts/generated/owner.toml".bk &&
+    mv "../scripts/generated/owner.toml".bk "../scripts/generated/owner.toml"
 # funds validator accounts
 npx hardhat fund-validators --network $NETWORK
 cd $CURRENT_WD
@@ -50,6 +49,9 @@ if [[ -z "${FACTORY_ADDRESS}" ]]; then
 fi
 
 cd $BRIDGE_DIR
+echo
+# deploy ALCB
+npx hardhat --network $NETWORK deploy-alcb --factory-address ${FACTORY_ADDRESS}
 npx hardhat set-local-environment-interval-mining --network $NETWORK --interval 1000
 cd $CURRENT_WD
 


### PR DESCRIPTION
## Scope

This PR is adding a new script to deploy ALCB locally in order to test alicenet transactions.  This is just a workaround, in the near future ALCB will be deployed using the same script as the rest of the contracts. 
