### PR TITLE
Add READMEs to application, crypto, and dynamics directories

### DIFF
--- a/application/README.md
+++ b/application/README.md
@@ -1,0 +1,48 @@
+# Application
+
+## About
+
+This directory holds everything related to `application`.
+In particular, this holds everything related to transactions.
+
+`application` is meant to be independent of `consensus`,
+as the focus is on the current state and allowable (valid)
+state transitions.
+In that way, there is no real notion of time within `application`.
+Time is tracked within `consensus`,
+which keeps track of time by reaching consensus on the current state.
+
+## `deposit/`
+
+Here we store information related to the Deposit Handler.
+This tracks all deposits received as well as all deposits consumed.
+Deposits are unique `UTXO`s because their validity
+**must come from the outside**:
+it is easy to check if a deposit has been double spent,
+but **the validity of a deposit requires a trusted source**.
+In this case, the trusted source is from an event emission on Ethereum.
+
+## `indexer/`
+
+This holds the various indexers used within `application`.
+
+## `minedtx/`
+
+This stores information related to mined transactions;
+that is, transactions which have been included in previous blocks.
+
+## `objs/`
+
+This contains all definitions related to transactions and `UTXO` types.
+
+## `pendingtx/`
+
+This stores information to handling pending transactions;
+that is, transactions which provide valid changes to state.
+
+## `utxohandler/`
+
+This stores everything related to handling `UTXO`s.
+One important function defined on the `utxohandler` is `IsValid`,
+which determines if a collection of transactions form
+a valid state transition.

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -1,0 +1,37 @@
+# Crypto
+
+## About
+
+This directory holds all code related to cryptography.
+**Any and all changes should be handled with great care.**
+
+The primary cryptographic hash function used throughout AliceNet
+is `Keccak256` as in Ethereum.
+Any reference should call the hash function defined here.
+
+## `bn256/`
+
+This directory holds everything related to the `bn256` elliptic curve
+(sometimes called `alt_bn128`).
+It defines an bilinear pairing
+associated with an elliptic curve over a finite field
+with a 256-bit prime.
+Although originally designed to provide 128 bits of security,
+recent developments in factoring algorithms have reduced this security
+to approximately 100 bits.
+
+This is the one of the bilinear pairings Ethereum uses,
+and we used their code as the foundation.
+A hash-to-curve algorithm was added to enable BLS signatures.
+The bilinear pairing enables enable threshold group signatures
+for consensus.
+Additional code related to the Distributed Key Generation protocol
+has been added as well.
+
+## `secp256k1/`
+
+This directory holds everything related to the `secp256k1`
+elliptic curve.
+This is the elliptic curve used by Ethereum and Bitcoin
+for digital signatures.
+The code essentially wraps the `secp256k1` code from Ethereum.

--- a/dynamics/README.md
+++ b/dynamics/README.md
@@ -1,0 +1,15 @@
+# Dynamics
+
+## About
+
+This directory holds everything related to `dynamics`.
+This purpose of Dynamics is to allow for certain parameters
+to change periodically on epoch boundaries.
+The idea is that eventually these parameters will be controlled
+by the governance system.
+
+Prototypical examples include fees for objects and transactions:
+these fees determine the overall cost of using AliceNet.
+Additional examples include timeouts for Consensus:
+these timeouts control how quickly blocks are processed
+as well as determine the time between snapshots.


### PR DESCRIPTION
## Scope

Top-level README's are being added to the `application/`, `crypto/`, and `dynamics/` directories.

## Why?

- This is being done to assist understanding of the code base.
- Contributes to #290 


## Todos

Continue adding additional information throughout.