### PR TITLE
Tweaking code coverage PR noise

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,13 @@
+codecov:
+  notify:
+    after_n_builds: 4
 ignore:
   - "bridge/bindings/**"
   - "cmd/**"
   - "proto/**"
   - "**/*.mockgen.go"
+comment:
+  after_n_builds: 4
 coverage:
   status:
     project:

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,11 @@ ignore:
   - "**/*.mockgen.go"
 coverage:
   status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
     patch:
       default:
-        target: 50%
+        target: auto
+        threshold: 2%


### PR DESCRIPTION
## Scope

Tweaking code coverage requirements.

## Why?

PR checks have been getting noisy.