### PR TITLE
Fix vscode debug configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,69 +1,73 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "name": "bootnode",
-      "type": "go",
-      "request": "launch",
-      "mode": "debug",
-      "program": "${workspaceFolder}/cmd",
-      "cwd": "${workspaceFolder}",
-      "args": ["--config", "./scripts/base-files/bootnode.toml", "bootnode"]
-    },
-    {
-      "name": "val1",
-      "type": "go",
-      "request": "launch",
-      "mode": "debug",
-      "program": "${workspaceFolder}/cmd",
-      "cwd": "${workspaceFolder}",
-      "args": [
-        "--config",
-        "./scripts/generated/config/validator1.toml",
-        "validator"
-      ]
-    },
-    {
-      "name": "val2",
-      "type": "go",
-      "request": "launch",
-      "mode": "debug",
-      "program": "${workspaceFolder}/cmd",
-      "cwd": "${workspaceFolder}",
-      "args": [
-        "--config",
-        "./scripts/generated/config/validator2.toml",
-        "validator"
-      ]
-    },
-    {
-      "name": "val3",
-      "type": "go",
-      "request": "launch",
-      "mode": "debug",
-      "program": "${workspaceFolder}/cmd",
-      "cwd": "${workspaceFolder}",
-      "args": [
-        "--config",
-        "./scripts/generated/config/validator3.toml",
-        "validator"
-      ]
-    },
-    {
-      "name": "val4",
-      "type": "go",
-      "request": "launch",
-      "mode": "debug",
-      "program": "${workspaceFolder}/cmd",
-      "cwd": "${workspaceFolder}",
-      "args": [
-        "--config",
-        "./scripts/generated/config/validator4.toml",
-        "validator"
-      ]
-    }
-  ]
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "bootnode",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd",
+            "cwd": "${workspaceFolder}",
+            "args": [
+                "--config",
+                "./scripts/base-files/bootnode.toml",
+                "bootnode"
+            ]
+        },
+        {
+            "name": "val1",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd",
+            "cwd": "${workspaceFolder}",
+            "args": [
+                "--config",
+                "./scripts/generated/config/validator1.toml",
+                "node"
+            ]
+        },
+        {
+            "name": "val2",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd",
+            "cwd": "${workspaceFolder}",
+            "args": [
+                "--config",
+                "./scripts/generated/config/validator2.toml",
+                "node"
+            ]
+        },
+        {
+            "name": "val3",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd",
+            "cwd": "${workspaceFolder}",
+            "args": [
+                "--config",
+                "./scripts/generated/config/validator3.toml",
+                "node"
+            ]
+        },
+        {
+            "name": "val4",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd",
+            "cwd": "${workspaceFolder}",
+            "args": [
+                "--config",
+                "./scripts/generated/config/validator4.toml",
+                "node"
+            ]
+        }
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,18 @@
 {
-  "coverage-gutters.coverageBaseDir": "bridge/coverage/**",
-  "coverage-gutters.coverageReportFileName": "bridge/coverage/**/index.html",
-  "coverage-gutters.partialGutterIconPathLight": "rgba(163, 149, 0, 0.4)",
-  "coverage-gutters.partialGutterIconPathDark": "rgba(163, 149, 0, 0.4)",
-  "coverage-gutters.noGutterIconPathLight": "rgba(163, 149, 0, 0.4)",
-  "coverage-gutters.coverageFileNames": [
-    "lcov.info",
-    "cov.xml",
-    "coverage.xml",
-    "jacoco.xml",
-    "coverage.cobertura.xml"
-  ]
+    "coverage-gutters.coverageBaseDir": "bridge/coverage/**",
+    "coverage-gutters.coverageReportFileName": "bridge/coverage/**/index.html",
+    "coverage-gutters.partialGutterIconPathLight": "rgba(163, 149, 0, 0.4)",
+    "coverage-gutters.partialGutterIconPathDark": "rgba(163, 149, 0, 0.4)",
+    "coverage-gutters.noGutterIconPathLight": "rgba(163, 149, 0, 0.4)",
+    "coverage-gutters.coverageFileNames": [
+        "lcov.info",
+        "cov.xml",
+        "coverage.xml",
+        "jacoco.xml",
+        "coverage.cobertura.xml"
+    ],
+    "mochaExplorer.cwd": "./bridge",
+    "mochaExplorer.configFile": "./bridge/.mocharc.json",
+    "mochaExplorer.mochaPath": "./bridge/node_modules/mocha",
+    "mochaExplorer.fullTrace": true,
 }

--- a/bridge/.mocharc.json
+++ b/bridge/.mocharc.json
@@ -1,4 +1,5 @@
 {
-  "require": "ts-node/register/files",
-  "timeout": 240000
+  "require": "hardhat/register",
+  "timeout": 240000,
+  "_": ["test/**/*.{j,t}s"]
 }


### PR DESCRIPTION
## Scope

This PR should allow us to debug typescript tests with the mocha test explorer function. This PR also fixes the initialization of the golang debugger. 