### PR TITLE
Fix typescript linter execution

### DIFF
--- a/bridge/.eslintrc.js
+++ b/bridge/.eslintrc.js
@@ -48,5 +48,6 @@ module.exports = {
       },
     ],
     "node/no-unpublished-import": ["off"],
+    "node/no-unpublished-require": ["off"],
   },
 };

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "typechain": "hardhat typechain",
     "lint-solidity": "solhint 'contracts/**/*.sol' 'test/**/*.sol'",
-    "lint": "eslint test/**/*.ts scripts/**/*.ts",
+    "lint": "eslint 'test/**/*.ts' 'scripts/**/*.ts' --fix",
     "test": "hardhat test --show-stack-traces",
     "test-parallel": "npm run test -- --parallel",
     "format": "prettier --write ../",

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "typechain": "hardhat typechain",
     "lint-solidity": "solhint 'contracts/**/*.sol' 'test/**/*.sol'",
-    "lint": "eslint 'test/**/*.ts' 'scripts/**/*.ts' --fix",
+    "lint": "eslint 'test/**/*.ts' 'scripts/**/*.ts'",
     "test": "hardhat test --show-stack-traces",
     "test-parallel": "npm run test -- --parallel",
     "format": "prettier --write ../",

--- a/bridge/scripts/generateImmutableAuth.ts
+++ b/bridge/scripts/generateImmutableAuth.ts
@@ -20,13 +20,13 @@ task("generate-immutable-auth-contract", "Generate contracts")
     undefined
   )
   .setAction(async ({ input, output }, hre) => {
-    let contractNameSaltMap = [];
+    const contractNameSaltMap = [];
     let immutableContract = "";
     let contracts;
 
     if (input === undefined) {
       const allContracts = await getAllContracts(hre.artifacts);
-      let deploymentList = await getSortedDeployList(
+      const deploymentList = await getSortedDeployList(
         allContracts,
         hre.artifacts
       );
@@ -37,23 +37,23 @@ task("generate-immutable-auth-contract", "Generate contracts")
 
     for (let i = 0; i < contracts.length; i++) {
       const fullyQualifiedName = contracts[i];
-      let contractName = fullyQualifiedName.split(":")[1];
-      let salt = await getSalt(contractName, hre);
+      const contractName = fullyQualifiedName.split(":")[1];
+      const salt = await getSalt(contractName, hre);
       contractNameSaltMap.push([contractName, salt]);
     }
 
     immutableContract += templateImmutableFactory;
     for (const contractNameSalt of contractNameSaltMap) {
-      let name = contractNameSalt[0];
-      let salt = contractNameSalt[1];
-      let c = new Contract(name, salt);
+      const name = contractNameSalt[0];
+      const salt = contractNameSalt[1];
+      const c = new Contract(name, salt);
       immutableContract += templateContract(c);
     }
 
     if (output === undefined) {
       output = "contracts/utils/";
     } else {
-      checkUserDirPath(output);
+      await checkUserDirPath(output);
     }
     fs.writeFileSync(output + "ImmutableAuth.sol", immutableContract);
   });

--- a/bridge/scripts/lib/deployment/factoryStateUtil.ts
+++ b/bridge/scripts/lib/deployment/factoryStateUtil.ts
@@ -164,9 +164,9 @@ export async function updateList(
 export async function getATokenMinterAddress(network: string) {
   // fetch whats in the factory config file
   const config = await readFactoryState(FACTORY_STATE_PATH);
-  let proxies = config[network].proxies;
+  const proxies = config[network].proxies;
   for (let i = 0; i < proxies.length; i++) {
-    let name = proxies[i].logicName;
+    const name = proxies[i].logicName;
     if (name === "ATokenMinter") {
       return proxies[i].proxyAddress;
     }
@@ -175,9 +175,9 @@ export async function getATokenMinterAddress(network: string) {
 
 export async function getBTokenAddress(network: string) {
   const config = await readFactoryState(FACTORY_STATE_PATH);
-  let staticContracts = config[network].staticContracts;
+  const staticContracts = config[network].staticContracts;
   for (let i = 0; i < staticContracts.length; i++) {
-    let name = staticContracts[i].templateName;
+    const name = staticContracts[i].templateName;
     if (name === "BToken") {
       return staticContracts[i].metaAddress;
     }
@@ -186,9 +186,9 @@ export async function getBTokenAddress(network: string) {
 
 export async function getATokenAddress(network: string) {
   const config = await readFactoryState(FACTORY_STATE_PATH);
-  let staticContracts = config[network].staticContracts;
+  const staticContracts = config[network].staticContracts;
   for (let i = 0; i < staticContracts.length; i++) {
-    let name = staticContracts[i].templateName;
+    const name = staticContracts[i].templateName;
     if (name === "AToken") {
       return staticContracts[i].metaAddress;
     }

--- a/bridge/test/publicStaking/business-logic/accumulator-slush.test.ts
+++ b/bridge/test/publicStaking/business-logic/accumulator-slush.test.ts
@@ -63,7 +63,7 @@ describe("PublicStaking: Accumulator and slush invariance", async () => {
       credits += 1000n;
       for (let i = 0; i < numberUsers; i++) {
         // Perform slushSkim
-        let deltaAccum = ethStateSlush / totalShares;
+        const deltaAccum = ethStateSlush / totalShares;
         ethStateSlush -= deltaAccum * totalShares;
         ethStateAccum += deltaAccum;
         // compute payout
@@ -74,7 +74,8 @@ describe("PublicStaking: Accumulator and slush invariance", async () => {
           [tokensID[i]]
         );
         // compute payout
-        let diffAccum = ethStateAccum - userPosition.accumulatorEth.toBigInt();
+        const diffAccum =
+          ethStateAccum - userPosition.accumulatorEth.toBigInt();
         let payoutEst = diffAccum * sharesPerUser;
         let payoutRem = payoutEst;
         payoutEst /= scaleFactor;
@@ -120,7 +121,7 @@ describe("PublicStaking: Accumulator and slush invariance", async () => {
     );
     for (let i = 0; i < numberUsers; i++) {
       // Perform slushSkim
-      let deltaAccum = ethStateSlush / totalShares;
+      const deltaAccum = ethStateSlush / totalShares;
       ethStateSlush -= deltaAccum * totalShares;
       ethStateAccum += deltaAccum;
       // compute payout
@@ -131,7 +132,7 @@ describe("PublicStaking: Accumulator and slush invariance", async () => {
         [tokensID[i]]
       );
       // compute payout
-      let diffAccum = ethStateAccum - userPosition.accumulatorEth.toBigInt();
+      const diffAccum = ethStateAccum - userPosition.accumulatorEth.toBigInt();
       let payoutEst = diffAccum * sharesPerUser;
       let payoutRem = payoutEst;
       payoutEst /= scaleFactor;
@@ -198,20 +199,21 @@ describe("PublicStaking: Accumulator and slush invariance", async () => {
       ethStateSlush += 7n * scaleFactor;
       for (let i = 0; i < numberUsers; i++) {
         // Prep for collect
-        let deltaAccum = ethStateSlush / totalShares;
+        const deltaAccum = ethStateSlush / totalShares;
         ethStateSlush -= deltaAccum * totalShares;
         ethStateAccum += deltaAccum;
         // get position info
-        let [userPosition] = await callFunctionAndGetReturnValues(
+        const [userPosition] = await callFunctionAndGetReturnValues(
           fixture.publicStaking,
           "getPosition",
           users[i] as SignerWithAddress,
           [tokensID[i]]
         );
         // compute payout eth
-        let diffAccum = ethStateAccum - userPosition.accumulatorEth.toBigInt();
+        const diffAccum =
+          ethStateAccum - userPosition.accumulatorEth.toBigInt();
         let payoutEst = diffAccum * userPosition.shares.toBigInt();
-        if (totalShares == userPosition.shares.toBigInt()) {
+        if (totalShares === userPosition.shares.toBigInt()) {
           payoutEst += ethStateSlush;
           ethStateSlush = 0n;
         }
@@ -257,20 +259,21 @@ describe("PublicStaking: Accumulator and slush invariance", async () => {
 
       for (let i = 0; i < numberUsers; i++) {
         // Prep for collect
-        let deltaAccum = ethStateSlush / totalShares;
+        const deltaAccum = ethStateSlush / totalShares;
         ethStateSlush -= deltaAccum * totalShares;
         ethStateAccum += deltaAccum;
         // get position info
-        let [userPosition] = await callFunctionAndGetReturnValues(
+        const [userPosition] = await callFunctionAndGetReturnValues(
           fixture.publicStaking,
           "getPosition",
           users[i] as SignerWithAddress,
           [tokensID[i]]
         );
         // compute payout eth
-        let diffAccum = ethStateAccum - userPosition.accumulatorEth.toBigInt();
+        const diffAccum =
+          ethStateAccum - userPosition.accumulatorEth.toBigInt();
         let payoutEst = diffAccum * userPosition.shares.toBigInt();
-        if (totalShares == userPosition.shares.toBigInt()) {
+        if (totalShares === userPosition.shares.toBigInt()) {
           payoutEst += ethStateSlush;
           ethStateSlush = 0n;
         }
@@ -320,7 +323,7 @@ describe("PublicStaking: Accumulator and slush invariance", async () => {
     // compute payout eth
     let diffAccum = ethStateAccum - userPosition.accumulatorEth.toBigInt();
     let payoutEst = diffAccum * userPosition.shares.toBigInt();
-    if (totalShares == userPosition.shares.toBigInt()) {
+    if (totalShares === userPosition.shares.toBigInt()) {
       payoutEst += ethStateSlush;
       ethStateSlush = 0n;
     }
@@ -347,7 +350,7 @@ describe("PublicStaking: Accumulator and slush invariance", async () => {
     // compute payout eth
     diffAccum = ethStateAccum - userPosition.accumulatorEth.toBigInt();
     payoutEst = diffAccum * userPosition.shares.toBigInt();
-    if (totalShares == userPosition.shares.toBigInt()) {
+    if (totalShares === userPosition.shares.toBigInt()) {
       payoutEst += ethStateSlush;
       ethStateSlush = 0n;
     }
@@ -380,7 +383,7 @@ describe("PublicStaking: Accumulator and slush invariance", async () => {
     // compute payout eth
     diffAccum = ethStateAccum - userPosition.accumulatorEth.toBigInt();
     payoutEst = diffAccum * userPosition.shares.toBigInt();
-    if (totalShares == userPosition.shares.toBigInt()) {
+    if (totalShares === userPosition.shares.toBigInt()) {
       payoutEst += ethStateSlush;
       ethStateSlush = 0n;
     }
@@ -400,20 +403,20 @@ describe("PublicStaking: Accumulator and slush invariance", async () => {
     credits += depositAmount;
     for (let i = 0; i < numberUsers; i++) {
       // Prep for collect
-      let deltaAccum = ethStateSlush / totalShares;
+      const deltaAccum = ethStateSlush / totalShares;
       ethStateSlush -= deltaAccum * totalShares;
       ethStateAccum += deltaAccum;
       // get position info
-      let [userPosition] = await callFunctionAndGetReturnValues(
+      const [userPosition] = await callFunctionAndGetReturnValues(
         fixture.publicStaking,
         "getPosition",
         users[i] as SignerWithAddress,
         [tokensID[i]]
       );
       // compute payout eth
-      let diffAccum = ethStateAccum - userPosition.accumulatorEth.toBigInt();
+      const diffAccum = ethStateAccum - userPosition.accumulatorEth.toBigInt();
       let payoutEst = diffAccum * userPosition.shares.toBigInt();
-      if (totalShares == userPosition.shares.toBigInt()) {
+      if (totalShares === userPosition.shares.toBigInt()) {
         payoutEst += ethStateSlush;
         ethStateSlush = 0n;
       }

--- a/bridge/test/publicStaking/business-logic/collect.test.ts
+++ b/bridge/test/publicStaking/business-logic/collect.test.ts
@@ -460,7 +460,7 @@ describe("PublicStaking: Collect Tokens and ETH profit", async () => {
     // compute payout
     let diffAccum = tokenStateAccum - userPosition.accumulatorToken.toBigInt();
     let payoutEst = diffAccum * sharesPerUser;
-    if (totalShares == userPosition.shares.toBigInt()) {
+    if (totalShares === userPosition.shares.toBigInt()) {
       payoutEst += tokenStateSlush;
       tokenStateSlush = 0n;
     }
@@ -517,9 +517,9 @@ describe("PublicStaking: Collect Tokens and ETH profit", async () => {
     let numUsers = 2;
     for (let i = 0; i < numUsers; i++) {
       // Perform slushSkim
-      let totalSharesBN = await fixture.publicStaking.getTotalShares();
-      let totalShares = totalSharesBN.toBigInt();
-      let deltaAccum = tokenStateSlush / totalShares;
+      const totalSharesBN = await fixture.publicStaking.getTotalShares();
+      const totalShares = totalSharesBN.toBigInt();
+      const deltaAccum = tokenStateSlush / totalShares;
       tokenStateSlush -= deltaAccum * totalShares;
       tokenStateAccum += deltaAccum;
       // get position info
@@ -530,10 +530,10 @@ describe("PublicStaking: Collect Tokens and ETH profit", async () => {
         [tokensID[i]]
       );
       // compute payout
-      let diffAccum =
+      const diffAccum =
         tokenStateAccum - userPosition.accumulatorToken.toBigInt();
       let payoutEst = diffAccum * sharesPerUser;
-      if (totalShares == userPosition.shares.toBigInt()) {
+      if (totalShares === userPosition.shares.toBigInt()) {
         payoutEst += tokenStateSlush;
         tokenStateSlush = 0n;
       }
@@ -591,9 +591,9 @@ describe("PublicStaking: Collect Tokens and ETH profit", async () => {
     numUsers = 3;
     for (let i = 0; i < numUsers; i++) {
       // Perform slushSkim
-      let totalSharesBN = await fixture.publicStaking.getTotalShares();
-      let totalShares = totalSharesBN.toBigInt();
-      let deltaAccum = tokenStateSlush / totalShares;
+      const totalSharesBN = await fixture.publicStaking.getTotalShares();
+      const totalShares = totalSharesBN.toBigInt();
+      const deltaAccum = tokenStateSlush / totalShares;
       tokenStateSlush -= deltaAccum * totalShares;
       tokenStateAccum += deltaAccum;
       // get position info
@@ -604,10 +604,10 @@ describe("PublicStaking: Collect Tokens and ETH profit", async () => {
         [tokensID[i]]
       );
       // compute payout
-      let diffAccum =
+      const diffAccum =
         tokenStateAccum - userPosition.accumulatorToken.toBigInt();
       let payoutEst = diffAccum * sharesPerUser;
-      if (totalShares == userPosition.shares.toBigInt()) {
+      if (totalShares === userPosition.shares.toBigInt()) {
         payoutEst += tokenStateSlush;
         tokenStateSlush = 0n;
       }
@@ -648,9 +648,9 @@ describe("PublicStaking: Collect Tokens and ETH profit", async () => {
     // only 2 users collect
     for (let i = 0; i < 2; i++) {
       // Perform slushSkim
-      let totalSharesBN = await fixture.publicStaking.getTotalShares();
-      let totalShares = totalSharesBN.toBigInt();
-      let deltaAccum = tokenStateSlush / totalShares;
+      const totalSharesBN = await fixture.publicStaking.getTotalShares();
+      const totalShares = totalSharesBN.toBigInt();
+      const deltaAccum = tokenStateSlush / totalShares;
       tokenStateSlush -= deltaAccum * totalShares;
       tokenStateAccum += deltaAccum;
       // get position info
@@ -661,10 +661,10 @@ describe("PublicStaking: Collect Tokens and ETH profit", async () => {
         [tokensID[i]]
       );
       // compute payout
-      let diffAccum =
+      const diffAccum =
         tokenStateAccum - userPosition.accumulatorToken.toBigInt();
       let payoutEst = diffAccum * sharesPerUser;
-      if (totalShares == userPosition.shares.toBigInt()) {
+      if (totalShares === userPosition.shares.toBigInt()) {
         payoutEst += tokenStateSlush;
         tokenStateSlush = 0n;
       }
@@ -702,9 +702,9 @@ describe("PublicStaking: Collect Tokens and ETH profit", async () => {
     // All users collect this time, we expect the last user witch didn't withdrawal last time to get more
     for (let i = 0; i < numUsers; i++) {
       // Perform slushSkim
-      let totalSharesBN = await fixture.publicStaking.getTotalShares();
-      let totalShares = totalSharesBN.toBigInt();
-      let deltaAccum = tokenStateSlush / totalShares;
+      const totalSharesBN = await fixture.publicStaking.getTotalShares();
+      const totalShares = totalSharesBN.toBigInt();
+      const deltaAccum = tokenStateSlush / totalShares;
       tokenStateSlush -= deltaAccum * totalShares;
       tokenStateAccum += deltaAccum;
       // get position info
@@ -715,10 +715,10 @@ describe("PublicStaking: Collect Tokens and ETH profit", async () => {
         [tokensID[i]]
       );
       // compute payout
-      let diffAccum =
+      const diffAccum =
         tokenStateAccum - userPosition.accumulatorToken.toBigInt();
       let payoutEst = diffAccum * sharesPerUser;
-      if (totalShares == userPosition.shares.toBigInt()) {
+      if (totalShares === userPosition.shares.toBigInt()) {
         payoutEst += tokenStateSlush;
         tokenStateSlush = 0n;
       }
@@ -775,7 +775,7 @@ describe("PublicStaking: Collect Tokens and ETH profit", async () => {
     // compute payout token
     diffAccum = tokenStateAccum - userPosition.accumulatorToken.toBigInt();
     payoutEst = diffAccum * sharesPerUser;
-    if (totalShares == userPosition.shares.toBigInt()) {
+    if (totalShares === userPosition.shares.toBigInt()) {
       payoutEst += tokenStateSlush;
       tokenStateSlush = 0n;
     }
@@ -787,7 +787,7 @@ describe("PublicStaking: Collect Tokens and ETH profit", async () => {
     // compute payout eth
     let diffAccumEth = ethStateAccum - userPosition.accumulatorEth.toBigInt();
     let payoutEstEth = diffAccumEth * sharesPerUser;
-    if (totalShares == userPosition.shares.toBigInt()) {
+    if (totalShares === userPosition.shares.toBigInt()) {
       payoutEstEth += ethStateSlush;
       ethStateSlush = 0n;
     }
@@ -831,7 +831,7 @@ describe("PublicStaking: Collect Tokens and ETH profit", async () => {
     // compute payout token
     diffAccum = tokenStateAccum - userPosition.accumulatorToken.toBigInt();
     payoutEst = diffAccum * sharesPerUser;
-    if (totalShares == userPosition.shares.toBigInt()) {
+    if (totalShares === userPosition.shares.toBigInt()) {
       payoutEst += tokenStateSlush;
       tokenStateSlush = 0n;
     }
@@ -843,7 +843,7 @@ describe("PublicStaking: Collect Tokens and ETH profit", async () => {
     // compute payout eth
     diffAccumEth = ethStateAccum - userPosition.accumulatorEth.toBigInt();
     payoutEstEth = diffAccumEth * sharesPerUser;
-    if (totalShares == userPosition.shares.toBigInt()) {
+    if (totalShares === userPosition.shares.toBigInt()) {
       payoutEstEth += ethStateSlush;
       ethStateSlush = 0n;
     }
@@ -886,7 +886,7 @@ describe("PublicStaking: Collect Tokens and ETH profit", async () => {
     // compute payout token
     diffAccum = tokenStateAccum - userPosition.accumulatorToken.toBigInt();
     payoutEst = diffAccum * sharesPerUser;
-    if (totalShares == userPosition.shares.toBigInt()) {
+    if (totalShares === userPosition.shares.toBigInt()) {
       payoutEst += tokenStateSlush;
       tokenStateSlush = 0n;
     }
@@ -898,7 +898,7 @@ describe("PublicStaking: Collect Tokens and ETH profit", async () => {
     // compute payout eth
     diffAccumEth = ethStateAccum - userPosition.accumulatorEth.toBigInt();
     payoutEstEth = diffAccumEth * sharesPerUser;
-    if (totalShares == userPosition.shares.toBigInt()) {
+    if (totalShares === userPosition.shares.toBigInt()) {
       payoutEstEth += ethStateSlush;
       ethStateSlush = 0n;
     }

--- a/bridge/test/setup.ts
+++ b/bridge/test/setup.ts
@@ -136,7 +136,7 @@ export const getValidatorEthAccount = async (
   } else {
     const balance = await ethers.provider.getBalance(validator.address);
     if (balance.eq(0)) {
-      signers[0].sendTransaction({
+      await signers[0].sendTransaction({
         to: validator.address,
         value: ethers.utils.parseEther(amount),
       });
@@ -171,14 +171,6 @@ export const createUsers = async (
   }
   return users;
 };
-
-async function getContractAddressFromDeployedStaticEvent(
-  tx: ContractTransaction
-): Promise<string> {
-  const eventSignature = "event DeployedStatic(address contractAddr)";
-  const eventName = "DeployedStatic";
-  return await getContractAddressFromEventLog(tx, eventSignature, eventName);
-}
 
 async function getContractAddressFromDeployedProxyEvent(
   tx: ContractTransaction
@@ -234,7 +226,7 @@ export const deployUpgradeableWithFactory = async (
   saltType?: string
 ): Promise<Contract> => {
   const _Contract = await ethers.getContractFactory(contractName);
-  let deployCode = _Contract.getDeployTransaction(...constructorArgs)
+  const deployCode = _Contract.getDeployTransaction(...constructorArgs)
     .data as BytesLike;
   const hre: any = await require("hardhat");
   const transaction = await factory.deployCreate(deployCode);


### PR DESCRIPTION
## Scope

The typescript linter was ignoring some files due to missing quotations of the paths in the npm script definition. This PR solves this bug and fixes all linter errors found in the typescript files. 
