### PR TITLE
removed contract info struct

### DIFF
--- a/bridge/contracts/AliceNetFactory.sol
+++ b/bridge/contracts/AliceNetFactory.sol
@@ -103,8 +103,7 @@ contract AliceNetFactory is AliceNetFactoryBase {
      * @param newContractAddress_: address of the contract to be added to registry
      */
     function addNewExternalContract(bytes32 salt_, address newContractAddress_) public onlyOwner {
-        bool ok = _extCodeSize(newContractAddress_) != 0;
-        _codeSizeZeroRevert(ok);
+        _codeSizeZeroRevert(_extCodeSize(newContractAddress_) != 0);
         _addNewExternalContract(salt_, newContractAddress_);
     }
 

--- a/bridge/contracts/libraries/factory/AliceNetFactoryBase.sol
+++ b/bridge/contracts/libraries/factory/AliceNetFactoryBase.sol
@@ -13,11 +13,6 @@ abstract contract AliceNetFactoryBase is DeterministicAddress, ProxyUpgrader {
         bytes data;
     }
 
-    struct ContractInfo {
-        bool exist;
-        address logicAddr;
-    }
-
     /**
     @dev owner role for privileged access to functions
     */
@@ -37,7 +32,7 @@ abstract contract AliceNetFactoryBase is DeterministicAddress, ProxyUpgrader {
     /// @dev more details here https://github.com/alicenet/alicenet/wiki/Metamorphic-Proxy-Contract
     bytes8 private constant _UNIVERSAL_DEPLOY_CODE = 0x38585839386009f3;
 
-    mapping(bytes32 => ContractInfo) internal _externalContractRegistry;
+    mapping(bytes32 => address) internal _externalContractRegistry;
 
     /**
      *@dev events that notify of contract deployment
@@ -328,11 +323,11 @@ abstract contract AliceNetFactoryBase is DeterministicAddress, ProxyUpgrader {
 
     /// Internal function to add a new address and "pseudo" salt to the externalContractRegistry
     function _addNewExternalContract(bytes32 salt_, address newContractAddress_) internal {
-        if (_externalContractRegistry[salt_].exist) {
+        if (_externalContractRegistry[salt_] != address(0)) {
             revert AliceNetFactoryBaseErrors.SaltAlreadyInUse(salt_);
         }
         _contracts.push(salt_);
-        _externalContractRegistry[salt_] = ContractInfo(true, newContractAddress_);
+        _externalContractRegistry[salt_] = newContractAddress_;
     }
 
     /**
@@ -348,9 +343,9 @@ abstract contract AliceNetFactoryBase is DeterministicAddress, ProxyUpgrader {
     //lookup allows anyone interacting with the contract to get the address of contract specified by its salt_
     function _lookup(bytes32 salt_) internal view returns (address) {
         // check if the salt belongs to any address in the external contract registry (contracts deployed outside the factory)
-        ContractInfo memory contractInfo = _externalContractRegistry[salt_];
-        if (contractInfo.exist) {
-            return contractInfo.logicAddr;
+        address contractInfo = _externalContractRegistry[salt_];
+        if (contractInfo != address(0)) {
+            return contractInfo;
         }
         return getMetamorphicContractAddress(salt_, address(this));
     }


### PR DESCRIPTION
## Scope
changed external contract mapping to map pseudo salt to contract address instead of contract info with 2 fields


## Why?

the same behavior can be achieved by comparing address stored to 0, saves gas

## Todos

If any, what are the follow-up tasks required other than merging this PR? Have they been arranged?

- [ ] ???
