### PR TITLE
Adjust deploy script to be compatible with geth

### DIFF
--- a/scripts/base-scripts/deploy.sh
+++ b/scripts/base-scripts/deploy.sh
@@ -9,13 +9,13 @@ NETWORK=${1:-"dev"}
 cd $BRIDGE_DIR
 
 # if on hardhat network this switches automine on to deploy faster
-npx hardhat set-local-environment-interval-mining --network $NETWORK --enable-auto-mine
+npx hardhat set-local-environment-interval-mining --network $NETWORK --interval 500
 
 # Copy the deployList to the generated folder so we have deploymentList and deploymentArgsTemplate in the same folder
 cp ../scripts/base-files/deploymentList ../scripts/generated/deploymentList
 cp ../scripts/base-files/deploymentArgsTemplate ../scripts/generated/deploymentArgsTemplate
 
-npx hardhat --network "$NETWORK" --show-stack-traces deploy-contracts --input-folder ../scripts/generated
+npx hardhat --network "$NETWORK" --show-stack-traces deploy-contracts --input-folder ../scripts/generated --wait-confirmation 1
 addr="$(grep -Pzo "\[$NETWORK\]\ndefaultFactoryAddress = \".*\"\n" ../scripts/generated/factoryState | grep -a "defaultFactoryAddress = .*" | awk '{print $NF}')"
 
 export FACTORY_ADDRESS=$addr
@@ -52,14 +52,13 @@ cd $BRIDGE_DIR
 echo
 # deploy ALCB
 npx hardhat --network $NETWORK deploy-alcb --factory-address ${FACTORY_ADDRESS}
-npx hardhat set-local-environment-interval-mining --network $NETWORK --interval 1000
 cd $CURRENT_WD
 
 ./scripts/main.sh register
 
 cd $BRIDGE_DIR
 npx hardhat --network $NETWORK set-min-ethereum-blocks-per-snapshot --factory-address $FACTORY_ADDRESS --block-num 10
-npx hardhat set-local-environment-interval-mining --network $NETWORK
+npx hardhat set-local-environment-interval-mining --network $NETWORK --interval 2500
 cd $CURRENT_WD
 
 if [[ -n "${AUTO_START_VALIDATORS}" ]]; then


### PR DESCRIPTION
This PR should make the scripts compatible with `geth` and `hardhat` at cost of making the deployment on hardhat a little bit slower.