### PR TITLE
[291] Enable lint errcheck

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,11 @@
         "go.toolsManagement.checkForUpdates": "local",
         "go.useLanguageServer": true,
         "go.gopath": "/go",
-        "go.goroot": "/usr/local/go"
+        "go.goroot": "/usr/local/go",
+        "go.lintTool": "golangci-lint",
+        "go.lintFlags": [
+          "--fast"
+        ]
       },
       "extensions": [
         "golang.Go",

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,9 +4,9 @@ run:
     - integration
     - flakes
 linters:
-  # Disabling linters until we get them fixed up.
-  disable:
+  enable:
     - errcheck
+  disable:
     - gosimple
     - govet
     - ineffassign

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,6 +6,7 @@ run:
 linters:
   enable:
     - errcheck
+  # Disabling linters until we get them fixed up.
   disable:
     - gosimple
     - govet

--- a/cmd/testutils/layer1_tx_spammer/main.go
+++ b/cmd/testutils/layer1_tx_spammer/main.go
@@ -283,14 +283,10 @@ func main() {
 	defer watcher.Close()
 	if isUsingTestAccounts {
 		// this function will block for finality delay blocks
-		err := tests.FundAccounts(eth, watcher, logger)
-		if err != nil {
+		if err := tests.FundAccounts(eth, watcher, logger); err != nil {
 			panic("Unable to fund test accounts")
 		}
 		tests.SetNextBlockBaseFee(eth.GetEndpoint(), 100_000_000_000)
-		if err != nil {
-			panic("Unable to fund set next block base fee")
-		}
 	}
 
 	// spawn num of Workers

--- a/cmd/testutils/layer1_tx_spammer/main.go
+++ b/cmd/testutils/layer1_tx_spammer/main.go
@@ -283,8 +283,14 @@ func main() {
 	defer watcher.Close()
 	if isUsingTestAccounts {
 		// this function will block for finality delay blocks
-		tests.FundAccounts(eth, watcher, logger)
+		err := tests.FundAccounts(eth, watcher, logger)
+		if err != nil {
+			panic("Unable to fund test accounts")
+		}
 		tests.SetNextBlockBaseFee(eth.GetEndpoint(), 100_000_000_000)
+		if err != nil {
+			panic("Unable to fund set next block base fee")
+		}
 	}
 
 	// spawn num of Workers

--- a/consensus/objs/rs.go
+++ b/consensus/objs/rs.go
@@ -465,10 +465,8 @@ func (b *RoundState) TrackExternalConflicts(v *Proposal) {
 		return
 	}
 	// is current
-	_, err := b.checkStaleAndConflict(v, false)
-	if err != nil {
-		return
-	}
+	// nolint:errcheck // review error checking for RoundState
+	b.checkStaleAndConflict(v, false)
 }
 
 func (b *RoundState) SetRCert(rc *RCert) error {

--- a/consensus/objs/rs.go
+++ b/consensus/objs/rs.go
@@ -465,7 +465,10 @@ func (b *RoundState) TrackExternalConflicts(v *Proposal) {
 		return
 	}
 	// is current
-	b.checkStaleAndConflict(v, false)
+	_, err := b.checkStaleAndConflict(v, false)
+	if err != nil {
+		return
+	}
 }
 
 func (b *RoundState) SetRCert(rc *RCert) error {

--- a/dynamics/db_test.go
+++ b/dynamics/db_test.go
@@ -37,7 +37,7 @@ func TestMock(t *testing.T) {
 
 	m := NewTestDB()
 
-	m.DB().Update(func(txn *badger.Txn) error {
+	err := m.DB().Update(func(txn *badger.Txn) error {
 		_, err := m.GetValue(txn, key)
 		if !errors.Is(err, ErrKeyNotPresent) {
 			t.Fatalf("should have failed: %v", err)
@@ -57,6 +57,9 @@ func TestMock(t *testing.T) {
 		}
 		return nil
 	})
+	if err != nil {
+		t.Fatal("unable to complete test")
+	}
 
 }
 
@@ -78,7 +81,7 @@ func TestGetSetNode(t *testing.T) {
 	db := initializeDB()
 
 	node := &Node{}
-	db.rawDB.Update(func(txn *badger.Txn) error {
+	_ = db.rawDB.Update(func(txn *badger.Txn) error {
 		err := db.SetNode(txn, node)
 		if err == nil {
 			t.Fatal("Should have raised error (1)")
@@ -124,7 +127,7 @@ func TestGetSetLinkedList(t *testing.T) {
 	db := initializeDB()
 
 	ll := &LinkedList{}
-	db.rawDB.Update(func(txn *badger.Txn) error {
+	_ = db.rawDB.Update(func(txn *badger.Txn) error {
 		err := db.SetLinkedList(txn, ll)
 		if err == nil {
 			t.Fatal("Should have raised error (1)")

--- a/dynamics/db_test.go
+++ b/dynamics/db_test.go
@@ -81,7 +81,7 @@ func TestGetSetNode(t *testing.T) {
 	db := initializeDB()
 
 	node := &Node{}
-	_ = db.rawDB.Update(func(txn *badger.Txn) error {
+	err := db.rawDB.Update(func(txn *badger.Txn) error {
 		err := db.SetNode(txn, node)
 		if err == nil {
 			t.Fatal("Should have raised error (1)")
@@ -120,6 +120,9 @@ func TestGetSetNode(t *testing.T) {
 		}
 		return nil
 	})
+	if err != nil {
+		t.Fatal("unable to complete test")
+	}
 }
 
 func TestGetSetLinkedList(t *testing.T) {
@@ -127,7 +130,7 @@ func TestGetSetLinkedList(t *testing.T) {
 	db := initializeDB()
 
 	ll := &LinkedList{}
-	_ = db.rawDB.Update(func(txn *badger.Txn) error {
+	err := db.rawDB.Update(func(txn *badger.Txn) error {
 		err := db.SetLinkedList(txn, ll)
 		if err == nil {
 			t.Fatal("Should have raised error (1)")
@@ -151,4 +154,7 @@ func TestGetSetLinkedList(t *testing.T) {
 		}
 		return nil
 	})
+	if err != nil {
+		t.Fatal("unable to complete test")
+	}
 }

--- a/dynamics/dynamics_test.go
+++ b/dynamics/dynamics_test.go
@@ -148,7 +148,10 @@ func TestStorageInit1(t *testing.T) {
 func TestStorageInitFromScratch(t *testing.T) {
 	t.Parallel()
 	s := &Storage{}
-	s.Init(NewTestDB(), newLogger())
+	err := s.Init(NewTestDB(), newLogger())
+	if err != nil {
+		t.Fatal("Database not initialized")
+	}
 
 	// since there's no node, the starting channel should be closed and no request
 	// against the storage should be allowed
@@ -171,7 +174,10 @@ func TestStorageInitWithPersistance(t *testing.T) {
 	}
 
 	s2 := &Storage{}
-	s2.Init(s.database.rawDB, s.logger)
+	err = s2.Init(s.database.rawDB, s.logger)
+	if err != nil {
+		t.Fatal("unable to initialize storage")
+	}
 
 	// Check dynamicValues == standardParameters
 	storageDVBytes, err := s2.DynamicValues.Marshal()

--- a/layer1/executor/model.go
+++ b/layer1/executor/model.go
@@ -3,10 +3,11 @@ package executor
 import (
 	"context"
 	"errors"
+	"sync"
+
 	"github.com/alicenet/alicenet/layer1/executor/marshaller"
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/transaction"
-	"sync"
 )
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -135,7 +136,7 @@ type ManagerResponseInfo struct {
 type requestStored struct {
 	BaseRequest
 	WrappedTask *marshaller.InstanceWrapper `json:"wrappedTask"`
-	killedAt    uint64                      `json:"killedAt"`
+	killedAt    uint64                      `json:"-"`
 }
 
 // responseStored for recovery.

--- a/layer1/executor/model.go
+++ b/layer1/executor/model.go
@@ -3,11 +3,10 @@ package executor
 import (
 	"context"
 	"errors"
-	"sync"
-
 	"github.com/alicenet/alicenet/layer1/executor/marshaller"
 	"github.com/alicenet/alicenet/layer1/executor/tasks"
 	"github.com/alicenet/alicenet/layer1/transaction"
+	"sync"
 )
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -136,7 +135,7 @@ type ManagerResponseInfo struct {
 type requestStored struct {
 	BaseRequest
 	WrappedTask *marshaller.InstanceWrapper `json:"wrappedTask"`
-	killedAt    uint64                      `json:"-"`
+	killedAt    uint64                      `json:"killedAt"`
 }
 
 // responseStored for recovery.

--- a/layer1/executor/task_executor.go
+++ b/layer1/executor/task_executor.go
@@ -113,7 +113,10 @@ func (te *TaskExecutor) handleTaskExecution(task tasks.Task, name string, taskId
 	// Clean up in case the task was killed
 	if task.WasKilled() {
 		task.GetLogger().Trace("task was externally killed, removing tx backup")
-		te.removeTxBackup(task.GetId())
+		err := te.removeTxBackup(task.GetId())
+		if err != nil {
+			task.GetLogger().Error("removal of tx back up failure")
+		}
 	}
 	task.Finish(err)
 }

--- a/layer1/executor/task_manager.go
+++ b/layer1/executor/task_manager.go
@@ -122,10 +122,7 @@ func (tm *TaskManager) eventLoop() {
 
 		case taskRequest, ok := <-tm.requestChan:
 			if !ok {
-				err := tm.onError(ErrReceivedRequestClosedChan)
-				if err != nil {
-					tm.logger.Warn("task manager is closing")
-				}
+				_ = tm.onError(ErrReceivedRequestClosedChan)
 				return
 			}
 			if taskRequest.response == nil {

--- a/layer1/executor/tasks/tests/register_test.go
+++ b/layer1/executor/tasks/tests/register_test.go
@@ -239,7 +239,8 @@ func TestRegisterTask_Group_1_Bad1(t *testing.T) {
 	dkgState.TransportPrivateKey = big.NewInt(0)
 	// Mess up public key; this should fail because it is invalid
 	dkgState.TransportPublicKey = [2]*big.Int{big.NewInt(0), big.NewInt(1)}
-	state.SaveDkgState(dkgDb, dkgState)
+	err = state.SaveDkgState(dkgDb, dkgState)
+	assert.NotNil(t, err)
 	_, err = registrationTask.Execute(ctx)
 	assert.NotNil(t, err)
 }
@@ -299,7 +300,8 @@ func TestRegisterTask_Group_2_Bad2(t *testing.T) {
 	dkgState.TransportPrivateKey = big.NewInt(0)
 	// Mess up public key; this should fail because it is invalid (the identity element)
 	dkgState.TransportPublicKey = [2]*big.Int{big.NewInt(0), big.NewInt(0)}
-	state.SaveDkgState(dkgDb, dkgState)
+	err = state.SaveDkgState(dkgDb, dkgState)
+	assert.NotNil(t, err)
 	_, err = registrationTask.Execute(ctx)
 	assert.NotNil(t, err)
 }


### PR DESCRIPTION
## Scope

1. Enabling linting on save for file in VS Code for errcheck. 
2. Resolve errcheck issues currently on master. 

## Why?

Code maintenance and readability 

## Todos

Keep the issue open because more linting needs to be completed before closing. 