### PR TITLE
Fix config file-path reference

### DIFF
--- a/cmd/testutils/extractor/main.go
+++ b/cmd/testutils/extractor/main.go
@@ -15,7 +15,7 @@ func main() {
 
 	bytes, err := os.ReadFile(*filePath)
 	if err != nil {
-		panic("Could not read file")
+		panic(fmt.Errorf("fatal error reading file: %w", err))
 	}
 	outerRegex := regexp.MustCompile(fmt.Sprintf(`\[%s\]\ndefaultFactoryAddress = \".*\"\n`, *network))
 	innerRegex := regexp.MustCompile(`defaultFactoryAddress = .*`)

--- a/scripts/base-scripts/deploy.sh
+++ b/scripts/base-scripts/deploy.sh
@@ -20,7 +20,7 @@ npx hardhat --network "$NETWORK" --show-stack-traces deploy-contracts --input-fo
 # -f  will check for the file existence but -s will check for file existence along with file size greater than 0 (zero).
 if [[ -s ../scripts/generated/factoryState ]]
 then
-  addr=$(go run ../cmd/testutils/extractor/main.go -n $NETWORK -p ../scripts/generated)
+    addr=$(go run ../cmd/testutils/extractor/main.go -n $NETWORK -p ../scripts/generated/factoryState)
 else
   echo "FactoryState file doesn't exist in scripts/generated/factoryState path. Exiting..."
   exit 1


### PR DESCRIPTION
## Scope

This PR is update `factoryState` file-path reference in `deploy.sh` and update `panic` message to print error in console in `cmd/testutils/extractor/main.go` file.

## Why?

To remove panic error while reading factoryState config file in `cmd/testutils/extractor/main.go`

## Todos

If any, what are the follow-up tasks required other than merging this PR? Have they been arranged?

- [ ] ???
