### PR TITLE
Cleaning out linting action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version-file: ./go.mod
-          cache: true
       - uses: golangci/golangci-lint-action@v3
 
   go-unit-tests:


### PR DESCRIPTION
## Scope

Lint action auto installs go already, no need to do that too.

## Why?

Reducing a few thousand lines of log warnings.
