### PR TITLE
Updating gotestfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       - uses: ./.github/actions/alicenet-config
       - run: go build ./...
       - name: Set up gotestfmt
-        run: go install github.com/gotesttools/gotestfmt@latest
+        run: go install github.com/gotesttools/gotestfmt/v2@latest
       - name: Run unit tests
         timeout-minutes: 20
         run: |
@@ -165,7 +165,7 @@ jobs:
       - run: npm --prefix bridge/ run compile
       - uses: ./.github/actions/alicenet-config
       - name: Set up gotestfmt
-        run: go install github.com/gotesttools/gotestfmt@latest
+        run: go install github.com/gotesttools/gotestfmt/v2@latest
       - name: Run tests ${{ matrix.test-cmd }}
         timeout-minutes: 45
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       - uses: ./.github/actions/alicenet-config
       - run: go build ./...
       - name: Set up gotestfmt
-        run: go install github.com/gotesttools/gotestfmt/v2@latest
+        run: go install github.com/gotesttools/gotestfmt/v2
       - name: Run unit tests
         timeout-minutes: 20
         run: |
@@ -165,7 +165,7 @@ jobs:
       - run: npm --prefix bridge/ run compile
       - uses: ./.github/actions/alicenet-config
       - name: Set up gotestfmt
-        run: go install github.com/gotesttools/gotestfmt/v2@latest
+        run: go install github.com/gotesttools/gotestfmt/v2
       - name: Run tests ${{ matrix.test-cmd }}
         timeout-minutes: 45
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       - uses: ./.github/actions/alicenet-config
       - run: go build ./...
       - name: Set up gotestfmt
-        run: go install gotesttools/gotestfmt@latest
+        run: go install github.com/gotesttools/gotestfmt@latest
       - name: Run unit tests
         timeout-minutes: 20
         run: |
@@ -165,7 +165,7 @@ jobs:
       - run: npm --prefix bridge/ run compile
       - uses: ./.github/actions/alicenet-config
       - name: Set up gotestfmt
-        run: go install gotesttools/gotestfmt@latest
+        run: go install github.com/gotesttools/gotestfmt@latest
       - name: Run tests ${{ matrix.test-cmd }}
         timeout-minutes: 45
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,12 +113,12 @@ jobs:
       - uses: ./.github/actions/alicenet-config
       - run: go build ./...
       - name: Set up gotestfmt
-        run: go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
+        run: go install gotesttools/gotestfmt@latest
       - name: Run unit tests
         timeout-minutes: 20
         run: |
           set -euo pipefail
-          go test -race -json -covermode=atomic -coverpkg ./... -coverprofile=coverage.out ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+          go test -race -json -covermode=atomic -coverpkg ./... -coverprofile=coverage.out ./... 2>&1 | tee /tmp/gotest.log | gotestfmt -hide all
       - uses: codecov/codecov-action@v3
         with:
           files: ./coverage.out
@@ -165,7 +165,7 @@ jobs:
       - run: npm --prefix bridge/ run compile
       - uses: ./.github/actions/alicenet-config
       - name: Set up gotestfmt
-        run: go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
+        run: go install gotesttools/gotestfmt@latest
       - name: Run tests ${{ matrix.test-cmd }}
         timeout-minutes: 45
         env:
@@ -173,7 +173,7 @@ jobs:
         run: |
           set -euo pipefail
           ./scripts/main.sh init 5
-          go test -tags=integration -race -json -covermode=atomic -coverpkg ./... -coverprofile=coverage.out -timeout=30m ${{ matrix.test-cmd }} 2>&1 | tee /tmp/gotest.log | gotestfmt
+          go test -tags=integration -race -json -covermode=atomic -coverpkg ./... -coverprofile=coverage.out -timeout=30m ${{ matrix.test-cmd }} 2>&1 | tee /tmp/gotest.log | gotestfmt -hide all
       - uses: codecov/codecov-action@v3
         with:
           files: ./coverage.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       - uses: ./.github/actions/alicenet-config
       - run: go build ./...
       - name: Set up gotestfmt
-        run: go install github.com/gotesttools/gotestfmt/v2
+        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt
       - name: Run unit tests
         timeout-minutes: 20
         run: |
@@ -165,7 +165,7 @@ jobs:
       - run: npm --prefix bridge/ run compile
       - uses: ./.github/actions/alicenet-config
       - name: Set up gotestfmt
-        run: go install github.com/gotesttools/gotestfmt/v2
+        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt
       - name: Run tests ${{ matrix.test-cmd }}
         timeout-minutes: 45
         env:

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
+	github.com/gotesttools/gotestfmt/v2 v2.4.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.14.0
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
@@ -101,7 +102,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
-	github.com/gotesttools/gotestfmt/v2 v2.4.1 // indirect
 	github.com/graph-gophers/graphql-go v1.3.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/gotesttools/gotestfmt/v2 v2.4.1 // indirect
 	github.com/graph-gophers/graphql-go v1.3.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -427,6 +427,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gotesttools/gotestfmt/v2 v2.4.1 h1:Ml+KPqPocp/KckpizL+tgsy/dlddI4/z2w6lgS7YIFE=
+github.com/gotesttools/gotestfmt/v2 v2.4.1/go.mod h1:oQJg2KZ2aGoqEbMC2PDaAeBYm0tOkocgixK9FzsCdp4=
 github.com/graph-gophers/graphql-go v1.3.0 h1:Eb9x/q6MFpCLz7jBCiP/WTxjSDrYLR1QY41SORZyNJ0=
 github.com/graph-gophers/graphql-go v1.3.0/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/tools.go
+++ b/tools.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/derision-test/go-mockgen/cmd/go-mockgen"
 	_ "github.com/ethereum/go-ethereum/cmd/abigen"
 	_ "github.com/ethereum/go-ethereum/cmd/geth"
+	_ "github.com/gotesttools/gotestfmt/v2"
 	_ "github.com/vburenin/ifacemaker"
 	_ "golang.org/x/tools/cmd/goimports"
 )


### PR DESCRIPTION
- gotestfmt moved to a new repository and old one is deprecated
- also reducing test verbosity
- closes #462
