### PR TITLE
291 Lint static check 

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,3 +11,4 @@ linters:
     - ineffassign
   # Disabling linters until we get them fixed up.
   disable:
+    - staticcheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,4 +11,3 @@ linters:
     - ineffassign
   # Disabling linters until we get them fixed up.
   disable:
-    - staticcheck

--- a/application/pendingtx/pending_test.go
+++ b/application/pendingtx/pending_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -268,7 +267,7 @@ func mustDelTx(t *testing.T, hndlr *Handler, tx *objs.Tx) {
 }
 
 func setup(t *testing.T) (*Handler, *mockTrie, func()) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	if err != nil {
 		if err := os.RemoveAll(dir); err != nil {
 			t.Fatal(err)
@@ -412,7 +411,7 @@ func TestGetProposal(t *testing.T) {
 }
 
 func TestGetProposal_2Txs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	if err != nil {
 		if err := os.RemoveAll(dir); err != nil {
 			t.Fatal(err)
@@ -471,7 +470,7 @@ func TestGetProposal_2Txs(t *testing.T) {
 }
 
 func TestGetProposal_WithNonUniqueTxs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	if err != nil {
 		if err := os.RemoveAll(dir); err != nil {
 			t.Fatal(err)
@@ -529,7 +528,7 @@ func TestGetProposal_WithNonUniqueTxs(t *testing.T) {
 }
 
 func TestGetProposal_With1InvalidTx(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	if err != nil {
 		if err := os.RemoveAll(dir); err != nil {
 			t.Fatal(err)
@@ -594,7 +593,7 @@ func TestGetProposal_With1InvalidTx(t *testing.T) {
 }
 
 func TestCheckIsValid_Valid(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	if err != nil {
 		if err := os.RemoveAll(dir); err != nil {
 			t.Fatal(err)
@@ -655,7 +654,7 @@ func TestCheckIsValid_Valid(t *testing.T) {
 }
 
 func TestCheckIsValid_UTXOInvalid(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	if err != nil {
 		if err := os.RemoveAll(dir); err != nil {
 			t.Fatal(err)
@@ -716,7 +715,7 @@ func TestCheckIsValid_UTXOInvalid(t *testing.T) {
 }
 
 func TestCheckIsValid_Missing_Invalid(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	if err != nil {
 		if err := os.RemoveAll(dir); err != nil {
 			t.Fatal(err)
@@ -785,7 +784,7 @@ func TestCheckIsValid_Missing_Invalid(t *testing.T) {
 }
 
 func TestCheckIsValid_Spent_Invalid(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	if err != nil {
 		if err := os.RemoveAll(dir); err != nil {
 			t.Fatal(err)
@@ -850,7 +849,7 @@ func TestCheckIsValid_Spent_Invalid(t *testing.T) {
 }
 
 func TestCheckIsValid_Error_Invalid(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	if err != nil {
 		if err := os.RemoveAll(dir); err != nil {
 			t.Fatal(err)

--- a/application/pendingtx/pending_test.go
+++ b/application/pendingtx/pending_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -267,19 +266,12 @@ func mustDelTx(t *testing.T, hndlr *Handler, tx *objs.Tx) {
 }
 
 func setup(t *testing.T) (*Handler, *mockTrie, func()) {
-	dir, err := os.MkdirTemp("", "badger-test")
-	if err != nil {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}
-	opts := badger.DefaultOptions(dir)
+	opts := badger.DefaultOptions(t.TempDir())
 	db, err := badger.Open(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
 	fn := func() {
-		defer os.RemoveAll(dir)
 		defer db.Close()
 	}
 	////////////////////////////////////////
@@ -411,19 +403,11 @@ func TestGetProposal(t *testing.T) {
 }
 
 func TestGetProposal_2Txs(t *testing.T) {
-	dir, err := os.MkdirTemp("", "badger-test")
-	if err != nil {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}
-	opts := badger.DefaultOptions(dir)
+	opts := badger.DefaultOptions(t.TempDir())
 	db, err := badger.Open(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	defer os.RemoveAll(dir)
 	defer db.Close()
 	////////////////////////////////////////
 	signer := &crypto.Secp256k1Signer{}
@@ -470,19 +454,11 @@ func TestGetProposal_2Txs(t *testing.T) {
 }
 
 func TestGetProposal_WithNonUniqueTxs(t *testing.T) {
-	dir, err := os.MkdirTemp("", "badger-test")
-	if err != nil {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}
-	opts := badger.DefaultOptions(dir)
+	opts := badger.DefaultOptions(t.TempDir())
 	db, err := badger.Open(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	defer os.RemoveAll(dir)
 	defer db.Close()
 	////////////////////////////////////////
 	signer := &crypto.Secp256k1Signer{}
@@ -528,19 +504,11 @@ func TestGetProposal_WithNonUniqueTxs(t *testing.T) {
 }
 
 func TestGetProposal_With1InvalidTx(t *testing.T) {
-	dir, err := os.MkdirTemp("", "badger-test")
-	if err != nil {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}
-	opts := badger.DefaultOptions(dir)
+	opts := badger.DefaultOptions(t.TempDir())
 	db, err := badger.Open(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	defer os.RemoveAll(dir)
 	defer db.Close()
 	////////////////////////////////////////
 	signer := &crypto.Secp256k1Signer{}
@@ -593,19 +561,11 @@ func TestGetProposal_With1InvalidTx(t *testing.T) {
 }
 
 func TestCheckIsValid_Valid(t *testing.T) {
-	dir, err := os.MkdirTemp("", "badger-test")
-	if err != nil {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}
-	opts := badger.DefaultOptions(dir)
+	opts := badger.DefaultOptions(t.TempDir())
 	db, err := badger.Open(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	defer os.RemoveAll(dir)
 	defer db.Close()
 	////////////////////////////////////////
 	signer := &crypto.Secp256k1Signer{}
@@ -654,19 +614,11 @@ func TestCheckIsValid_Valid(t *testing.T) {
 }
 
 func TestCheckIsValid_UTXOInvalid(t *testing.T) {
-	dir, err := os.MkdirTemp("", "badger-test")
-	if err != nil {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}
-	opts := badger.DefaultOptions(dir)
+	opts := badger.DefaultOptions(t.TempDir())
 	db, err := badger.Open(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	defer os.RemoveAll(dir)
 	defer db.Close()
 	////////////////////////////////////////
 	signer := &crypto.Secp256k1Signer{}
@@ -715,19 +667,11 @@ func TestCheckIsValid_UTXOInvalid(t *testing.T) {
 }
 
 func TestCheckIsValid_Missing_Invalid(t *testing.T) {
-	dir, err := os.MkdirTemp("", "badger-test")
-	if err != nil {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}
-	opts := badger.DefaultOptions(dir)
+	opts := badger.DefaultOptions(t.TempDir())
 	db, err := badger.Open(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	defer os.RemoveAll(dir)
 	defer db.Close()
 	////////////////////////////////////////
 	signer := &crypto.Secp256k1Signer{}
@@ -784,19 +728,11 @@ func TestCheckIsValid_Missing_Invalid(t *testing.T) {
 }
 
 func TestCheckIsValid_Spent_Invalid(t *testing.T) {
-	dir, err := os.MkdirTemp("", "badger-test")
-	if err != nil {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}
-	opts := badger.DefaultOptions(dir)
+	opts := badger.DefaultOptions(t.TempDir())
 	db, err := badger.Open(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	defer os.RemoveAll(dir)
 	defer db.Close()
 	////////////////////////////////////////
 	signer := &crypto.Secp256k1Signer{}
@@ -849,19 +785,11 @@ func TestCheckIsValid_Spent_Invalid(t *testing.T) {
 }
 
 func TestCheckIsValid_Error_Invalid(t *testing.T) {
-	dir, err := os.MkdirTemp("", "badger-test")
-	if err != nil {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}
-	opts := badger.DefaultOptions(dir)
+	opts := badger.DefaultOptions(t.TempDir())
 	db, err := badger.Open(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	defer os.RemoveAll(dir)
 	defer db.Close()
 	////////////////////////////////////////
 	signer := &crypto.Secp256k1Signer{}

--- a/application/txhandler_test.go
+++ b/application/txhandler_test.go
@@ -1,7 +1,6 @@
 package application
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -9,7 +8,7 @@ import (
 )
 
 func TestUTXOTrie(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/application/txhandler_test.go
+++ b/application/txhandler_test.go
@@ -1,23 +1,13 @@
 package application
 
 import (
-	"os"
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
 )
 
 func TestUTXOTrie(t *testing.T) {
-	dir, err := os.MkdirTemp("", "badger-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}()
-	opts := badger.DefaultOptions(dir)
+	opts := badger.DefaultOptions(t.TempDir())
 	db, err := badger.Open(opts)
 	if err != nil {
 		t.Fatal(err)

--- a/application/utxohandler/utxohandler_test.go
+++ b/application/utxohandler/utxohandler_test.go
@@ -1,7 +1,6 @@
 package utxohandler
 
 import (
-	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
@@ -80,7 +79,7 @@ func makeTxs(t *testing.T, s objs.Signer, v *objs.ValueStore) *objs.Tx {
 }
 
 func TestUTXOTrie(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/application/utxohandler/utxohandler_test.go
+++ b/application/utxohandler/utxohandler_test.go
@@ -1,7 +1,6 @@
 package utxohandler
 
 import (
-	"os"
 	"strconv"
 	"testing"
 
@@ -79,16 +78,7 @@ func makeTxs(t *testing.T, s objs.Signer, v *objs.ValueStore) *objs.Tx {
 }
 
 func TestUTXOTrie(t *testing.T) {
-	dir, err := os.MkdirTemp("", "badger-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}()
-	opts := badger.DefaultOptions(dir)
+	opts := badger.DefaultOptions(t.TempDir())
 	db, err := badger.Open(opts)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/firewalld/gcloud/metadata.go
+++ b/cmd/firewalld/gcloud/metadata.go
@@ -1,7 +1,7 @@
 package gcloud
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -20,7 +20,7 @@ func getMetadata(url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	res, err := ioutil.ReadAll(resp.Body)
+	res, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil
 	}

--- a/cmd/firewalld/lib/cmd.go
+++ b/cmd/firewalld/lib/cmd.go
@@ -2,7 +2,7 @@ package lib
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os/exec"
 )
 
@@ -29,7 +29,7 @@ func RunCmd(c ...string) ([]byte, error) {
 
 	var stderr []byte
 	go func() {
-		stderr, _ = ioutil.ReadAll(pipe)
+		stderr, _ = io.ReadAll(pipe)
 	}()
 	o, err := cmd.Output()
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"strings"
@@ -277,7 +277,7 @@ func main() {
 		// Read the config file
 		file, err := os.Open(config.Configuration.ConfigurationFileName)
 		if err == nil {
-			bs, err := ioutil.ReadAll(file)
+			bs, err := io.ReadAll(file)
 			if err == nil {
 				reader := bytes.NewReader(bs)
 				viper.SetConfigType("toml") // TODO: Set config type based on file extension. Viper supports more than toml.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"bytes"
-	"io"
 	"os"
 	"reflect"
 	"strings"
@@ -277,19 +275,13 @@ func main() {
 		// Read the config file
 		file, err := os.Open(config.Configuration.ConfigurationFileName)
 		if err == nil {
-			bs, err := io.ReadAll(file)
-			if err == nil {
-				reader := bytes.NewReader(bs)
-				viper.SetConfigType("toml") // TODO: Set config type based on file extension. Viper supports more than toml.
-				err := viper.ReadConfig(reader)
-				if err != nil {
-					logger.Warnf("Reading config failed:%q", err)
-				}
-			} else {
-				logger.Warnf("Reading file failed:%q", err)
+			err := viper.ReadConfig(file)
+			if err != nil {
+				logger.Warnf("unable to read config %s with err %q", file.Name(), err)
 			}
+			logger.Infof("config %s", file.Name())
 		} else {
-			logger.Debugf("Opening file failed: %q", err)
+			logger.Debugf("unable to open config %s with err %q", file.Name(), err)
 		}
 
 		/* The logic here feels backwards to me but it isn't.

--- a/consensus/gossip/state_test.go
+++ b/consensus/gossip/state_test.go
@@ -2,7 +2,6 @@ package gossip
 
 import (
 	"math/big"
-	"os"
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
@@ -25,16 +24,7 @@ func TestState(t *testing.T) {
 	if len(secpPubks) != len(bnShares) {
 		t.Fatal("key length mismatch")
 	}
-	dir, err := os.MkdirTemp("", "badger-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}()
-	opts := badger.DefaultOptions(dir)
+	opts := badger.DefaultOptions(t.TempDir())
 	DB, err := badger.Open(opts)
 	if err != nil {
 		t.Fatal(err)

--- a/consensus/gossip/state_test.go
+++ b/consensus/gossip/state_test.go
@@ -1,7 +1,6 @@
 package gossip
 
 import (
-	"io/ioutil"
 	"math/big"
 	"os"
 	"testing"
@@ -26,7 +25,7 @@ func TestState(t *testing.T) {
 	if len(secpPubks) != len(bnShares) {
 		t.Fatal("key length mismatch")
 	}
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/consensus/lstate/engine_test.go
+++ b/consensus/lstate/engine_test.go
@@ -58,6 +58,7 @@ func TestEngine_Status_Ok(t *testing.T) {
 	st, err := engine.Status(st)
 	assert.Nil(t, err)
 	assert.NotNil(t, st)
+	assert.NotEmpty(t, st)
 }
 
 func TestEngine_Status_Error(t *testing.T) {

--- a/dynamics/db_test.go
+++ b/dynamics/db_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/alicenet/alicenet/consensus/db"
@@ -16,7 +16,7 @@ import (
 )
 
 func NewTestRawDB() *badger.DB {
-	logging.GetLogger(constants.LoggerBadger).SetOutput(ioutil.Discard)
+	logging.GetLogger(constants.LoggerBadger).SetOutput(io.Discard)
 	db, err := utils.OpenBadger(context.Background().Done(), "", true)
 	if err != nil {
 		panic(err)

--- a/dynamics/values_test.go
+++ b/dynamics/values_test.go
@@ -57,14 +57,14 @@ func TestDynamicValuesCopy(t *testing.T) {
 	t.Parallel()
 	// Copy empty DynamicValues should fail
 	dv1 := &DynamicValues{}
-	dv2, err := dv1.Copy()
+	_, err := dv1.Copy()
 	if err == nil {
 		t.Fatal(err)
 	}
 
 	// Copy DynamicValues with parameters
 	dv1 = &DynamicValues{EncoderVersion: 0, ProposalTimeout: 3000, MaxBlockSize: 30000}
-	dv2, err = dv1.Copy()
+	dv2, err := dv1.Copy()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dynamics/values_test.go
+++ b/dynamics/values_test.go
@@ -57,8 +57,7 @@ func TestDynamicValuesCopy(t *testing.T) {
 	t.Parallel()
 	// Copy empty DynamicValues should fail
 	dv1 := &DynamicValues{}
-	_, err := dv1.Copy()
-	if err == nil {
+	if _, err := dv1.Copy(); err == nil {
 		t.Fatal(err)
 	}
 

--- a/layer1/ethereum/ethereum.go
+++ b/layer1/ethereum/ethereum.go
@@ -6,12 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/console/prompt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/ethereum/go-ethereum/console/prompt"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
@@ -250,7 +250,7 @@ func (eth *Client) unlockAccount(acct accounts.Account) error {
 	}
 
 	// Open the account key file
-	keyJSON, err := ioutil.ReadFile(acct.URL.Path)
+	keyJSON, err := os.ReadFile(acct.URL.Path)
 	if err != nil {
 		return err
 	}

--- a/layer1/executor/task_executor_test.go
+++ b/layer1/executor/task_executor_test.go
@@ -2,7 +2,6 @@ package executor
 
 import (
 	"errors"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"testing"
@@ -282,7 +281,7 @@ func Test_TaskExecutor_ReceiptWithErrorAndFailure(t *testing.T) {
 }
 
 func Test_TaskExecutor_Recovering(t *testing.T) {
-	dir, err := ioutil.TempDir("", "db-test")
+	dir, err := os.MkdirTemp("", "db-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/layer1/executor/task_manager.go
+++ b/layer1/executor/task_manager.go
@@ -291,7 +291,6 @@ func (tm *TaskManager) processTaskResponse(executorResponse ExecutorResponse) er
 	case <-tm.closeChan:
 		return tasks.ErrTaskExecutionMechanismClosed
 	default:
-		logger := tm.logger
 		task, present := tm.Schedule[executorResponse.Id]
 		if !present {
 			tm.logger.Warnf("received an internal response for non existing task with id %s", executorResponse.Id)
@@ -309,7 +308,7 @@ func (tm *TaskManager) processTaskResponse(executorResponse ExecutorResponse) er
 		taskResp.HandlerResponse.writeResponse(executorResponse.Err)
 		tm.Responses[executorResponse.Id] = taskResp
 
-		logger = getTaskLoggerComplete(tm.logger, task)
+		logger := getTaskLoggerComplete(tm.logger, task)
 		if executorResponse.Err != nil {
 			if !errors.Is(executorResponse.Err, tasks.ErrTaskKilled) {
 				logger.Errorf("Task executed with error: %v", executorResponse.Err)

--- a/layer1/executor/tasks/tests/snapshot_test.go
+++ b/layer1/executor/tasks/tests/snapshot_test.go
@@ -431,7 +431,7 @@ func GenerateBlockSignature(t *testing.T, bnSigners []*crypto.BNGroupSigner, n i
 	}
 	s := new(crypto.BNGroupSigner)
 	mpk, err := bn256.MarshalBigIntSlice(mpkI)
-	require.Nil(t, err)
+	assert.Nil(t, err)
 	err = s.SetGroupPubk(mpk)
 	require.Nil(t, err)
 

--- a/layer1/monitor/events/ethdkg.go
+++ b/layer1/monitor/events/ethdkg.go
@@ -145,9 +145,6 @@ func ProcessRegistrationComplete(contracts layer1.AllSmartContracts, logger *log
 	logEntry := logger.WithField("eventProcessor", "ProcessRegistrationComplete")
 	logEntry.Info("processing registration complete")
 
-	shareDistributionTask := &dkgtasks.ShareDistributionTask{}
-	disputeMissingShareDistributionTask := &dkgtasks.DisputeMissingShareDistributionTask{}
-
 	dkgState, err := state.GetDkgState(monDB)
 	if err != nil {
 		logEntry.Errorf("Failed to load dkgState on ProcessRegistrationComplete: %v", err)
@@ -270,9 +267,6 @@ func ProcessShareDistribution(contracts layer1.AllSmartContracts, logger *logrus
 func ProcessShareDistributionComplete(contracts layer1.AllSmartContracts, logger *logrus.Entry, log types.Log, monDB *db.Database, taskHandler executor.TaskHandler) error {
 	logEntry := logger.WithField("eventProcessor", "ProcessShareDistributionComplete")
 	logEntry.Info("processing share distribution complete")
-
-	keyShareSubmissionTask := &dkgtasks.KeyShareSubmissionTask{}
-	disputeMissingKeySharesTask := &dkgtasks.DisputeMissingKeySharesTask{}
 
 	dkgState, err := state.GetDkgState(monDB)
 	if err != nil {
@@ -407,7 +401,6 @@ func ProcessKeyShareSubmissionComplete(contracts layer1.AllSmartContracts, logge
 		"BlockNumber": event.BlockNumber,
 	}).Info("ProcessKeyShareSubmissionComplete() ...")
 
-	mpkSubmissionTask := &dkgtasks.MPKSubmissionTask{}
 	dkgState, err := state.GetDkgState(monDB)
 	if err != nil {
 		logEntry.Errorf("Failed to load dkgState on ProcessKeyShareSubmissionComplete: %v", err)
@@ -420,7 +413,7 @@ func ProcessKeyShareSubmissionComplete(contracts layer1.AllSmartContracts, logge
 	}
 
 	// schedule MPK submission
-	mpkSubmissionTask = UpdateStateOnKeyShareSubmissionComplete(dkgState, event.BlockNumber.Uint64())
+	mpkSubmissionTask := UpdateStateOnKeyShareSubmissionComplete(dkgState, event.BlockNumber.Uint64())
 
 	if err = state.SaveDkgState(monDB, dkgState); err != nil {
 		logEntry.Errorf("Failed to save dkgState on ProcessKeyShareSubmissionComplete: %v", err)
@@ -471,8 +464,6 @@ func ProcessMPKSet(contracts layer1.AllSmartContracts, logger *logrus.Entry, log
 		"Nonce":       event.Nonce,
 		"MPK":         event.Mpk,
 	}).Info("ProcessMPKSet() ...")
-
-	gpkjSubmissionTask := &dkgtasks.GPKjSubmissionTask{}
 
 	dkgState, err := state.GetDkgState(monDB)
 	if err != nil {
@@ -557,7 +548,6 @@ func ProcessGPKJSubmissionComplete(contracts layer1.AllSmartContracts, logger *l
 		"BlockNumber": event.BlockNumber,
 	}).Info("ProcessGPKJSubmissionComplete() ...")
 
-	completionTask := &dkgtasks.CompletionTask{}
 	dkgState, err := state.GetDkgState(monDB)
 	if err != nil {
 		logEntry.Errorf("Failed to load dkgState on ProcessGPKJSubmissionComplete: %v", err)

--- a/localrpc/setup_test.go
+++ b/localrpc/setup_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"os"
 	"strconv"
@@ -420,7 +420,7 @@ func getSignerData() (*crypto.Secp256k1Signer, []byte) {
 
 func loadSettings(configFile string) {
 	file, _ := os.Open(configFile)
-	bs, _ := ioutil.ReadAll(file)
+	bs, _ := io.ReadAll(file)
 	reader := bytes.NewReader(bs)
 	viper.SetConfigType("toml")
 	err := viper.ReadConfig(reader)

--- a/test/mocks/db.go
+++ b/test/mocks/db.go
@@ -2,7 +2,7 @@ package mocks
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 
 	"github.com/dgraph-io/badger/v2"
 
@@ -13,7 +13,7 @@ import (
 )
 
 func NewTestRawDB() *badger.DB {
-	logging.GetLogger(constants.LoggerBadger).SetOutput(ioutil.Discard)
+	logging.GetLogger(constants.LoggerBadger).SetOutput(io.Discard)
 	db, err := utils.OpenBadger(context.Background().Done(), "", true)
 	if err != nil {
 		panic(err)

--- a/test/mocks/logger.go
+++ b/test/mocks/logger.go
@@ -1,7 +1,7 @@
 package mocks
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"strconv"
 
@@ -13,7 +13,7 @@ func NewMockLogger() *logrus.Logger {
 
 	testDebug, _ := strconv.ParseBool(os.Getenv("TEST_DEBUG"))
 	if !testDebug {
-		logger.SetOutput(ioutil.Discard)
+		logger.SetOutput(io.Discard)
 	}
 
 	return logger

--- a/utils/dbtools_test.go
+++ b/utils/dbtools_test.go
@@ -9,16 +9,7 @@ import (
 )
 
 func TestDBValue(t *testing.T) {
-	dir, err := os.MkdirTemp("", "dbtools-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}()
-	opts := badger.DefaultOptions(dir)
+	opts := badger.DefaultOptions(t.TempDir())
 	db, err := badger.Open(opts)
 	if err != nil {
 		t.Fatal(err)

--- a/utils/dbtools_test.go
+++ b/utils/dbtools_test.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -10,7 +9,7 @@ import (
 )
 
 func TestDBValue(t *testing.T) {
-	dir, err := ioutil.TempDir("", "dbtools-test")
+	dir, err := os.MkdirTemp("", "dbtools-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +65,7 @@ func TestDBValue(t *testing.T) {
 }
 
 func TestDBInt64(t *testing.T) {
-	dir, err := ioutil.TempDir("", "dbtools-test")
+	dir, err := os.MkdirTemp("", "dbtools-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/utils/dbtools_test.go
+++ b/utils/dbtools_test.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
@@ -56,16 +55,7 @@ func TestDBValue(t *testing.T) {
 }
 
 func TestDBInt64(t *testing.T) {
-	dir, err := os.MkdirTemp("", "dbtools-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}()
-	opts := badger.DefaultOptions(dir)
+	opts := badger.DefaultOptions(t.TempDir())
 	db, err := badger.Open(opts)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Scope

Perform partial lint of static check

## Why?

Static check identified large set of changes. Smaller commit happier reviewers. 
