### PR TITLE
Fix bug when tasks have the same start and end block

### DIFF
--- a/layer1/executor/task_manager.go
+++ b/layer1/executor/task_manager.go
@@ -249,7 +249,8 @@ func (tm *TaskManager) schedule(task tasks.Task, id string) (*HandlerResponse, e
 		start := task.GetStart()
 		end := task.GetEnd()
 
-		if start != 0 && end != 0 && start >= end {
+		// check if the task is expired
+		if start != 0 && end != 0 && start > end {
 			return nil, ErrWrongParams
 		}
 


### PR DESCRIPTION
Tasks are allowed to have the same start and end blocks. This special case happens for things like the migration of state from one chain to another.
