### PR TITLE
Fix flaky Foundry fuzz test for `mintTo`

### DIFF
--- a/bridge/test_sol/alcb/ALCB.mint.t.sol
+++ b/bridge/test_sol/alcb/ALCB.mint.t.sol
@@ -75,7 +75,7 @@ contract ALCBTest is Test {
 
     function testMintToFuzz(uint96 etherToSend, address destinationAddress) public {
         // if the value is less than market spread the function throws an error
-        if (etherToSend < marketSpread) return;
+        if (etherToSend < marketSpread || destinationAddress == zeroAddress) return;
         uint256 totalSupplyBefore = alcb.totalSupply();
 
         // fund the address


### PR DESCRIPTION
## Scope

Fixed flaky mintTo Foundry fuzz test for `mintTo` due to zero address being passed as fuzz parameter

## Why?

Prevent flakiness of the test

## Todos

If any, what are the follow-up tasks required other than merging this PR? Have they been arranged?

- [ ] ???
