### PR TITLE
[291] Lint bodyclose

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,10 +22,10 @@ linters:
     - thelper 
     - tparallel 
     - unused 
+    - bodyclose 
   # Disabling linters until we get them fixed up.
   disable:
     - staticcheck
-    - bodyclose # 2 issues
     - containedctx # 4 issues
     - contextcheck # 2 issues
     - cyclop # 25+ issues

--- a/layer1/tests/hardhat.go
+++ b/layer1/tests/hardhat.go
@@ -260,7 +260,7 @@ func (h *Hardhat) WaitForHardHatNode(ctx context.Context) error {
 			return ctx.Err()
 		case <-time.After(time.Second):
 			body := bytes.NewReader(buff.Bytes())
-			_, err := c.Post(
+			resp, err := c.Post(
 				h.url,
 				"application/json",
 				body,
@@ -268,6 +268,7 @@ func (h *Hardhat) WaitForHardHatNode(ctx context.Context) error {
 			if err != nil {
 				continue
 			}
+			defer resp.Body.Close()
 			logger.Infof("HardHat node started correctly")
 			return nil
 		}
@@ -410,6 +411,7 @@ func SendCommandViaRPC(url, command string, params ...interface{}) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	_, err = io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
## Scope

Close the body of a http request body 

## Why?

Improve lint checks