### PR TITLE
Fix UTXOTrie Bug

### DIFF
--- a/application/utxohandler/utxotrie/utxotrie.go
+++ b/application/utxohandler/utxotrie/utxotrie.go
@@ -72,7 +72,7 @@ func (ut *UTXOTrie) Init(_ uint32) error {
 }
 
 func (ut *UTXOTrie) GetCanonicalTrie(txn *badger.Txn) (*trie.SMT, error) {
-	root, err := GetCurrentStateRoot(txn)
+	root, err := GetCanonicalStateRoot(txn)
 	if err != nil {
 		if err != badger.ErrKeyNotFound {
 			utils.DebugTrace(ut.logger, err)


### PR DESCRIPTION
## Scope

A small bug is fixed; previously, the Canonical State Trie root was not being retrieved.

## Why?

Previous code was incorrectly calling the Current State Trie.