### PR TITLE
Fix bug stopping monitor from running

### DIFF
--- a/constants/shared.go
+++ b/constants/shared.go
@@ -92,7 +92,7 @@ const (
 // Badger VLog GC ratio.
 const (
 	BadgerDiscardRatio = 0.5
-	MonDBGCFreq        = time.Duration(600)
+	MonDBGCFreq        = time.Second * 600
 )
 
 // TODO Find a way to store this list that feels right.

--- a/layer1/monitor/monitor.go
+++ b/layer1/monitor/monitor.go
@@ -191,7 +191,7 @@ func (mon *monitor) Start() error {
 
 // eventLoop to process the events and chain changes.
 func (mon *monitor) eventLoop(logger *logrus.Entry) {
-	gcTimer := time.After(constants.MonDBGCFreq)
+	gcTimer := time.After(time.Second * constants.MonDBGCFreq)
 	for {
 		ctx, cf := context.WithTimeout(context.Background(), mon.timeout)
 		tock := mon.tickInterval
@@ -206,7 +206,7 @@ func (mon *monitor) eventLoop(logger *logrus.Entry) {
 			if err != nil {
 				logger.Debugf("Failed to reclaim any space during garbage collection: %v", err)
 			}
-			gcTimer = time.After(constants.MonDBGCFreq)
+			gcTimer = time.After(time.Second * constants.MonDBGCFreq)
 		case <-mon.closeChan:
 			mon.logger.Warnf("Received cancel request for event loop.")
 			cf()

--- a/layer1/monitor/monitor.go
+++ b/layer1/monitor/monitor.go
@@ -191,7 +191,7 @@ func (mon *monitor) Start() error {
 
 // eventLoop to process the events and chain changes.
 func (mon *monitor) eventLoop(logger *logrus.Entry) {
-	gcTimer := time.After(time.Second * constants.MonDBGCFreq)
+	gcTimer := time.After(constants.MonDBGCFreq)
 	for {
 		ctx, cf := context.WithTimeout(context.Background(), mon.timeout)
 		tock := mon.tickInterval
@@ -206,7 +206,7 @@ func (mon *monitor) eventLoop(logger *logrus.Entry) {
 			if err != nil {
 				logger.Debugf("Failed to reclaim any space during garbage collection: %v", err)
 			}
-			gcTimer = time.After(time.Second * constants.MonDBGCFreq)
+			gcTimer = time.After(constants.MonDBGCFreq)
 		case <-mon.closeChan:
 			mon.logger.Warnf("Received cancel request for event loop.")
 			cf()


### PR DESCRIPTION
Fixing a bug that is making the validators unable to initialize. The garbage collector is being run so fast that it's exhausting all resources. This change was introduced here: #603. The integration tests would have caught that. I'm working on re-enabling the integration tests on #617
