### PR TITLE
Add lookup for ALCB

### DIFF
--- a/layer1/chains/ethereum/contracts.go
+++ b/layer1/chains/ethereum/contracts.go
@@ -131,15 +131,13 @@ func (c *Contracts) lookupContracts() error {
 		)
 		logAndEat(logger, err)
 
-		// ALCB TODO: bring it back once we deploy ALCB c.alcbAddress, err = lookup("ALCB")
-		// logAndEat(logger, err) if bytes.Equal(c.alcbAddress.Bytes(), make([]byte, 20)) {
-		//  continue
-		// }
+		// ALCB
+		c.alcbAddress, err = lookup("ALCB")
+		logAndEat(logger, err)
+		if bytes.Equal(c.alcbAddress.Bytes(), make([]byte, 20)) {
+			continue
+		}
 
-		// workaround for now, just putting a random address, we should uncomment the code above
-		// once we deploy ALCB
-		c.alcbAddress = common.HexToAddress("0x0b1F9c2b7bED6Db83295c7B5158E3806d67eC5bc")
-		logger.Infof("Lookup up of \"%v\" is 0x%x", "ALCB", c.alcbAddress)
 		c.alcb, err = bindings.NewALCB(c.alcbAddress, eth.GetInternalClient())
 		logAndEat(logger, err)
 
@@ -180,16 +178,11 @@ func (c *Contracts) lookupContracts() error {
 		logAndEat(logger, err)
 
 		// Governance
-		// c.governanceAddress, err = lookup("Governance")
-		// logAndEat(logger, err)
-		// if bytes.Equal(c.governanceAddress.Bytes(), make([]byte, 20)) {
-		// 	continue
-		// }
-
-		// workaround for now, just putting a random address, should uncoment above code once we
-		// deploy governance
-		c.governanceAddress = common.HexToAddress("0x0b1F9c2b7bED6Db83295c7B5158E3806d67eC5be")
-		logger.Infof("Lookup up of \"%v\" is 0x%x", "Governance", c.governanceAddress)
+		c.governanceAddress, err = lookup("Governance")
+		logAndEat(logger, err)
+		if bytes.Equal(c.governanceAddress.Bytes(), make([]byte, 20)) {
+			continue
+		}
 
 		c.governance, err = bindings.NewGovernance(c.governanceAddress, eth.GetInternalClient())
 		logAndEat(logger, err)


### PR DESCRIPTION
The lookup for the ALCB address was deactivated during the last release due to some errors on the production cloud. Now, we can enable it again, since we will need it to test the alicenet transactions.
