### PR TITLE
feat: initial draft of prometheus metrics for peer count and status

### DIFF
--- a/cmd/bootnode/bootnode.go
+++ b/cmd/bootnode/bootnode.go
@@ -27,7 +27,7 @@ var Command = cobra.Command{
 	Long:  "Boot nodes do nothing put seed the peer table",
 	Run:   bootNode}
 
-// extractPort from passed address
+// extractPort from passed add1ress
 func extractPort(addr string) (uint32, error) {
 	_, portStr, err := net.SplitHostPort(addr)
 	if err != nil {

--- a/cmd/initialization/initialization.go
+++ b/cmd/initialization/initialization.go
@@ -3,10 +3,9 @@ package initialization
 import (
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/alicenet/alicenet/cmd/ethkey"
-
-	"path"
 
 	"github.com/alicenet/alicenet/config"
 	"github.com/alicenet/alicenet/logging"
@@ -216,6 +215,9 @@ func initializeFilesAndFolders(cmd *cobra.Command, args []string) {
 		},
 		Validator: config.ValidatorConfig{
 			SymmetricKey: validatorSymmetricKey,
+		},
+		Metrics: config.MetricsConfig{
+			Port: 9090,
 		},
 	}
 

--- a/config/settings.go
+++ b/config/settings.go
@@ -119,6 +119,10 @@ type EthKeyConfig struct {
 	NewPasswordFile string
 }
 
+type MetricsConfig struct {
+	Port uint16
+}
+
 type RootConfiguration struct {
 	ConfigurationFileName string
 	LoggingLevels         string // backwards compatibility
@@ -134,6 +138,7 @@ type RootConfiguration struct {
 	EthKey                EthKeyConfig
 	Version               string
 	Initialization        InitConfig
+	Metrics               MetricsConfig
 }
 
 // Configuration contains all active settings.

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d
 	github.com/holiman/uint256 v1.2.1
 	github.com/lightningnetwork/lnd v0.15.5-beta
+	github.com/prometheus/client_golang v1.12.1
 	github.com/rs/cors v1.8.3
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
@@ -45,6 +46,7 @@ require (
 	github.com/alecthomas/kingpin v2.2.6+incompatible // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd v0.23.4 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.2.2 // indirect
 	github.com/btcsuite/btcd/btcutil v1.1.3 // indirect
@@ -89,7 +91,6 @@ require (
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff // indirect
 	github.com/go-chi/chi/v5 v5.0.8 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
-	github.com/go-logfmt/logfmt v0.5.0 // indirect
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
@@ -116,7 +117,6 @@ require (
 	github.com/jdxcode/netrc v0.0.0-20221124155335-4616370d1a84 // indirect
 	github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e // indirect
 	github.com/jessevdk/go-flags v1.5.0 // indirect
-	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/karalabe/usb v0.0.2 // indirect
 	github.com/kkdai/bstream v1.0.0 // indirect
 	github.com/klauspost/compress v1.15.15 // indirect
@@ -152,7 +152,9 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.12.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.32.1 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/prometheus/tsdb v0.7.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rjeczalik/notify v0.9.1 // indirect

--- a/localrpc/setup_test.go
+++ b/localrpc/setup_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/viper"
 
 	"github.com/alicenet/alicenet/application"
@@ -456,7 +457,9 @@ func initPeerManager(consGossipHandlers *gossip.Handlers, consReqHandler *reques
 		config.Configuration.Transport.FirewallHost,
 		config.Configuration.Transport.P2PListeningAddress,
 		config.Configuration.Transport.PrivateKey,
-		config.Configuration.Transport.UPnP)
+		config.Configuration.Transport.UPnP,
+		prometheus.NewRegistry(),
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -1,0 +1,64 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/alicenet/alicenet/logging"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	defaultPath = "/metrics"
+)
+
+type MetricServer struct {
+	promPort uint32
+	registry *prometheus.Registry
+	server   http.Server
+}
+
+func NewServer(promPort uint16, registry *prometheus.Registry) *MetricServer {
+	if registry == nil {
+		registry = prometheus.NewRegistry()
+	}
+	m := http.NewServeMux()
+	m.Handle(defaultPath, promhttp.Handler())
+	logging.GetLogger("metrics").
+		WithField("path", defaultPath).
+		WithField("msg", "initialising prometheus metrics")
+	return &MetricServer{
+		server: http.Server{
+			Addr:    fmt.Sprintf(":%d", promPort),
+			Handler: m,
+		},
+		registry: registry,
+	}
+}
+
+func (s *MetricServer) Start() {
+	logging.GetLogger("metrics").
+		WithField("path", defaultPath).
+		WithField("msg", "starting prometheus metric server")
+	if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		logging.GetLogger("metrics").
+			WithField("error", err.Error()).
+			WithField("msg", "exiting prometheus metric server")
+	}
+}
+
+func (s *MetricServer) Stop(ctx context.Context) error {
+	logging.GetLogger("metrics").
+		WithField("msg", "exiting prometheus metric server")
+	err := s.server.Shutdown(ctx)
+	if err != nil {
+		logging.GetLogger("metrics").
+			WithField("msg", "failed to exit prometheus metric server cleanly")
+		return err
+	}
+	logging.GetLogger("metrics").
+		WithField("msg", "successfully exited prometheus metric server")
+	return nil
+}

--- a/peering/metrics.go
+++ b/peering/metrics.go
@@ -1,0 +1,30 @@
+package peering
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	metricLabelState = "state"
+
+	metricStateActive   = "active"
+	metricStateInactive = "inactive"
+)
+
+// Peers manages peer metrics
+type Peers struct {
+	peerCount *prometheus.GaugeVec
+}
+
+// NewPeerMetrics takes in a prometheus registry and initializes
+// and registers relay metrics. It returns those registered Peers.
+func NewPeerMetrics(r prometheus.Registerer) *Peers {
+	return &Peers{
+		peerCount: promauto.With(r).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "peer_count",
+				Help: "the total count of peers connected and their state",
+			}, []string{metricLabelState}),
+	}
+}


### PR DESCRIPTION
## Scope

What is changing with this PR?
Quickly put together this PR to begin discussions relating to introducing prometheus metrics to the alicenet client runtime.

## Why?
Improve operational visibility for node operators 

## Todos
- [ ] Discuss which other metrics may be useful to node operators
- [ ] Properly implement the graceful shutdown process on the metrics server
- [ ] Read the metric server port from configuration
- [ ] Metrics will only be collected when a given function is called for peers, need to look deeper to see if this could be problematic.